### PR TITLE
Add operator registry and visual-export recording

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,8 @@ npm-debug.log*
 .env.production
 
 # push for netlift
+
+# Local agent/tooling state
+.beads/
+.claude/
+docs/plans/

--- a/feature-dev-docs/feature-dev-operator-registry/decisions.md
+++ b/feature-dev-docs/feature-dev-operator-registry/decisions.md
@@ -1,0 +1,52 @@
+# Operator Registry - Decisions Log
+
+Append-only log of architectural decisions.
+
+---
+
+## 2026-05-07 18:49 PDT - Codex GPT-5
+
+### Decision: Build the operator layer as a registry-backed hidden console
+
+**Context:** Signal-23 needs room to expand the website with internal release, visual, export, and ROI surfaces without making the public homepage or terminal feel like a conventional navigation site.
+
+**Options Considered:**
+
+1. Add public navigation for visual and release pages.
+2. Create one-off hidden pages without a shared data model.
+3. Add a structured registry and render an internal operator console from it.
+
+**Decision:** Add `src/data/transmissions.ts` and render `/operator` plus `/operator/transmissions/:slug` from that registry.
+
+**Rationale:** A registry gives future visuals, releases, exports, Racksmith artifacts, and ROI work a shared metadata spine. Keeping the route hidden preserves the public site's sparse surface while still giving operators an explicit map.
+
+---
+
+## 2026-05-07 18:49 PDT - Codex GPT-5
+
+### Decision: Treat `/operator` as aesthetic privacy, not authentication
+
+**Context:** The operator route should not accidentally appear in public navigation or search results, but this slice does not require real access control.
+
+**Options Considered:**
+
+1. Add no controls and rely on the route being unlinked.
+2. Add crawler hints only.
+3. Add client-side passphrase protection.
+4. Add Netlify-level authentication or basic auth.
+
+**Decision:** Use no public links, `public/robots.txt`, client-side `noindex,nofollow` meta tags, and Netlify `X-Robots-Tag` headers. Do not add authentication in this slice.
+
+**Rationale:** Noindex controls match the current goal: preserve the public-facing mystery without pretending the route is actually private. Real security can be added later with server-side protection if the route starts containing sensitive data.
+
+---
+
+## 2026-05-07 19:39 PDT - Codex GPT-5
+
+### Decision: Classify hidden visualization routes as visual
+
+**Context:** Some hidden art routes have interactive or reactive behavior, but the operator registry currently needs a practical taxonomy for production surfaces rather than an implementation taxonomy.
+
+**Decision:** Treat every soft-secret visualization route from `decay` onward as `visual`. Keep `interactive` available for command/workflow surfaces such as the public terminal.
+
+**Rationale:** The operator map should answer what a route is used for. The hidden art routes are visual systems, even when they include motion, capture, or reactive logic.

--- a/feature-dev-docs/feature-dev-operator-registry/requirements.md
+++ b/feature-dev-docs/feature-dev-operator-registry/requirements.md
@@ -1,0 +1,61 @@
+# Operator Registry - Requirements
+
+## Summary
+
+The operator registry is a hidden internal map for Signal-23 routes and transmissions. It gives operators a structured view of public routes, soft-secret art routes, commerce routes, and deprecated routes without adding public navigation or changing the terminal command directory.
+
+## Inputs
+
+Registry entries live in `src/data/transmissions.ts`.
+
+Each entry includes:
+
+- `slug`: stable registry identifier used by operator detail routes
+- `route`: site path that the entry describes
+- `title`: display name for the route or transmission
+- `type`: route category such as visual, interactive, page, or commerce
+- `status`: current operational state
+- `visibility`: public, soft-secret, operator-only, or deprecated
+- `release`: optional release association
+- `tags`: searchable descriptors
+- `exportUse`: intended export targets
+- `notes`: optional operator-facing context
+- `addedAt`: date the entry was added to the registry
+
+## Outputs
+
+`/operator` renders a searchable and filterable table of all registry entries.
+
+`/operator/transmissions/:slug` renders a generic detail view for any registry entry.
+
+Both operator routes set a client-side `robots` meta tag with `noindex,nofollow`. Netlify also sends `X-Robots-Tag: noindex, nofollow` for `/operator` and `/operator/*`.
+
+## Constraints
+
+The operator layer is hidden for presentation, not secured for privacy. It must not be linked from the homepage, public navigation, or terminal command list.
+
+The registry is the source of truth for operator route metadata. New transmission routes should be added to the registry when they become meaningful operator surfaces.
+
+Public routes and soft-secret routes may appear inside the operator UI, but the operator UI itself remains reachable only by direct URL.
+
+Soft-secret visualization routes are classified as `visual` by default. `interactive` is reserved for surfaces whose primary purpose is command or workflow interaction, such as the public terminal.
+
+## Edge Cases
+
+Unknown detail slugs render a not-found state inside the operator shell.
+
+Entries without export targets render `NONE` instead of implying export support.
+
+Deprecated compatibility routes can remain in the registry when they still exist in the router.
+
+Long tags, routes, and titles must wrap or scroll without overlapping surrounding controls.
+
+The desktop operator table must occupy the full operator shell width and distribute columns across the available space.
+
+## User Flows
+
+An operator visits `/operator`, searches or filters by type, status, visibility, tag, release, route, or notes, then opens a route or a registry detail page.
+
+An operator visits `/operator/transmissions/decay` directly and sees route metadata, export intent, tags, notes, and adjacent registry navigation.
+
+Search engines and crawlers that respect standard hints receive both `robots.txt` disallow rules and `noindex,nofollow` headers for operator routes.

--- a/feature-dev-docs/feature-dev-operator-registry/tests.md
+++ b/feature-dev-docs/feature-dev-operator-registry/tests.md
@@ -1,0 +1,56 @@
+# Operator Registry - Test Specifications
+
+## Acceptance Criteria
+
+- Visiting `/operator` displays every entry from `src/data/transmissions.ts`.
+- The homepage and terminal command list do not link to `/operator`.
+- Search matches title, slug, route, type, status, visibility, release, notes, tags, and export targets.
+- Type, status, and visibility filters narrow the table without changing the registry data.
+- Soft-secret visualization routes from `decay` onward are classified as `visual`.
+- The desktop table spans the full operator content width instead of occupying only the left side of the page.
+- Each row links to `/operator/transmissions/:slug`.
+- Detail pages render metadata for any registry entry.
+- Unknown detail slugs render a not-found state with a path back to `/operator`.
+- Entries without export targets display `NONE`.
+- `/operator` and `/operator/*` receive `X-Robots-Tag: noindex, nofollow` in Netlify configuration.
+- `public/robots.txt` disallows `/operator` and `/operator/`.
+
+## Unit Test Expectations
+
+Registry data should contain unique slugs and routes for all current router paths that need operator visibility.
+
+Filtering behavior should be deterministic for empty queries, case-insensitive text queries, and combined type/status/visibility filters.
+
+Detail lookup should return the matching registry entry for a valid slug and no entry for an unknown slug.
+
+## Integration Paths
+
+Path 1: Operator index
+
+1. Load `/operator`.
+2. Confirm summary totals and table rows render.
+3. Search `decay`.
+4. Confirm `DECAY SIGNAL` remains visible and unrelated routes are hidden.
+5. Clear search and filter visibility to `soft-secret`.
+6. Confirm public routes are hidden.
+
+Path 2: Operator detail
+
+1. Load `/operator/transmissions/decay`.
+2. Confirm title, route, status, visibility, tags, export targets, and notes render.
+3. Open the route link and confirm it points to `/decay`.
+4. Use the back link to return to `/operator`.
+
+Path 3: Discovery controls
+
+1. Build the site.
+2. Confirm `public/robots.txt` is copied into the build output.
+3. Confirm `netlify.toml` defines noindex headers for `/operator` and `/operator/*`.
+
+## Edge Case Tests
+
+Long route and tag values should wrap or scroll without overlapping other UI.
+
+Mobile widths should render table rows as stacked label/value pairs.
+
+Deprecated routes should stay visible in the registry but clearly show deprecated visibility and archived status.

--- a/feature-dev-docs/feature-dev-visual-export/decisions.md
+++ b/feature-dev-docs/feature-dev-visual-export/decisions.md
@@ -1,0 +1,147 @@
+# Visual Export - Decisions Log
+
+Append-only log of architectural decisions.
+
+---
+
+## 2026-05-07 20:17 PDT - Codex GPT-5
+
+### Decision: Use existing soft-secret routes as export engines
+
+**Context:** Signal-23 already has hidden visual pages that work as standalone route surfaces. The export workflow needs reusable engines without adding public navigation or duplicating visual systems.
+
+**Decision:** Keep each visual at its existing route and add export behavior through metadata and query parameters.
+
+**Rationale:** Existing routes already carry the visual identity and release context. Query-param export mode keeps normal viewing intact, avoids new public route exposure, and gives operators direct links for repeatable capture setups.
+
+---
+
+## 2026-05-07 20:17 PDT - Codex GPT-5
+
+### Decision: Split lightweight registry intent from detailed visual capability metadata
+
+**Context:** The operator registry already has `exportUse` metadata. Export implementation needs more detail than a flat target list, including seeds, duration, aspect support, recording method, controls, and hardware-feed safety.
+
+**Decision:** Preserve `exportUse` as the summary field and add a future `visualExport` capability object for visual transmissions.
+
+**Rationale:** The registry index can stay scannable while detail pages and route validation use richer capability data. This avoids overloading the existing field and keeps future operator UI predictable.
+
+---
+
+## 2026-05-07 20:17 PDT - Codex GPT-5
+
+### Decision: Treat browser capture as the v1 output source
+
+**Context:** Export targets need usable source material, but a full transcoding or upload pipeline would add infrastructure before the route contract is proven.
+
+**Decision:** v1 export produces browser-rendered source output suitable for manual or local recording. Final MP4/WebM/PNG/WebP delivery can be created downstream.
+
+**Rationale:** Browser capture is enough to validate aspect ratio, seed, duration, framing, and hardware-feed behavior. Transcoding and social upload automation can follow once the visual route contract is stable.
+
+---
+
+## 2026-05-07 20:46 PDT - Codex GPT-5
+
+### Decision: Constrain v1 metadata to browser-source export behavior
+
+**Context:** The v1 decision treats browser-rendered output as the source and leaves capture/transcoding outside the app. Detailed recording methods, output formats, fixed control flags, custom aspect ratios, and future targets would imply implementation commitments that v1 does not make.
+
+**Decision:** Use a smaller `VisualExportCapability` shape with supported targets, default target, seed support, duration support, fixed named aspect ratios, `capture`, hardware-feed safety, and operator notes.
+
+**Rationale:** The schema should describe the behavior v1 can validate. In-page recording transports, final delivery formats, control metadata, custom ratios, and future target IDs can be added when the feature that needs them lands.
+
+---
+
+## 2026-05-07 20:46 PDT - Codex GPT-5
+
+### Decision: Use `target` as the export-mode switch
+
+**Context:** The earlier URL contract used both `mode=export` and `target=...`, which created two sources of truth for the same state.
+
+**Decision:** The presence of `target` means export mode. No `target` means normal mode.
+
+**Rationale:** A single signal avoids drift and keeps direct operator URLs shorter and easier to reason about.
+
+---
+
+## 2026-05-07 20:46 PDT - Codex GPT-5
+
+### Decision: Defer metadata provenance and registry duplication rules
+
+**Context:** `visualExport` metadata will duplicate some information from `exportUse`, and its lifecycle may need provenance separate from the parent `Transmission`. Route-specific hardware-feed safety also requires audit rather than assumption.
+
+**Decision:** Defer three questions until visual export metadata is implemented: whether `visualExport` needs its own `addedAt`, whether `exportUse` is derived from `visualExport.supportedTargets` or treated as a denormalized cache, and which routes are genuinely hardware-feed safe after interaction audits.
+
+**Rationale:** These questions matter at implementation time, but answering them before metadata exists would harden assumptions without evidence from the route audits.
+
+---
+
+## 2026-05-07 20:46 PDT - Codex GPT-5
+
+### Decision: Keep route scope canonical in the feature spec
+
+**Context:** Visual route lists will drift if repeated across requirements, decisions, tests, and implementation notes.
+
+**Decision:** Keep the canonical v1 visual route list only in `feature-spec.md` under Route Scope. Other visual export docs should reference that section instead of re-enumerating the routes.
+
+**Rationale:** A single route-scope list makes future route additions easier to review and keeps the living docs from disagreeing about which hidden visual routes are included.
+
+---
+
+## 2026-05-07 21:30 PDT - Codex GPT-5
+
+### Decision: Prove visual export on `/decay` before fanning out
+
+**Context:** The visual route family has varied internals, aspect behavior, randomness, and interaction requirements. Applying metadata and framing to every route before validating the contract would create broad churn and likely harden incorrect assumptions.
+
+**Decision:** Ship v1 as a `/decay` pilot with shared export settings parsing, aspect framing, runtime capability validation, `/decay` metadata, and `/decay` container-based Three.js sizing. Defer other visual routes and operator UI changes.
+
+**Rationale:** `/decay` already has complete export target intent and is a useful Canvas/Reel/hardware-feed candidate. A single-route pilot proves the contract while keeping later route work small and audit-driven.
+
+---
+
+## 2026-05-07 21:46 PDT - Codex GPT-5
+
+### Decision: Fit Decay camera distance to export aspect ratio
+
+**Context:** The first `/decay?target=canvas` export frame correctly created a 9:16 viewport, but the Three.js camera kept its original full-viewport distance. A narrower frame reduces horizontal field of view and cropped the shell edges.
+
+**Decision:** In export mode, Decay computes camera base distance from the mount container aspect ratio and a padded shell radius. Normal `/decay` mode keeps the original camera distance.
+
+**Rationale:** Export framing should preserve the visual subject inside the requested aspect ratio. Camera fitting keeps the route visually usable across canvas, square, vertical, and widescreen exports without changing the normal page.
+
+---
+
+## 2026-05-07 21:52 PDT - Codex GPT-5
+
+### Decision: Apply Decay camera fitting to narrow normal viewports
+
+**Context:** `/decay?target=canvas` was fixed, but plain `/decay` in a narrow mobile viewport such as iPhone SE still used the original desktop camera distance and could crop the shell.
+
+**Decision:** Decay now uses the fitted camera distance when the mount aspect ratio is portrait/narrow, even outside export mode. Landscape and desktop normal `/decay` keep the original camera distance.
+
+**Rationale:** Mobile previews and direct soft-secret route visits should preserve the core visual subject. Applying the same aspect-aware camera math to narrow normal viewports fixes mobile cropping without changing desktop composition.
+
+---
+
+## 2026-05-07 22:06 PDT - Codex GPT-5
+
+### Decision: Use Reclamation as the second visual export pilot
+
+**Context:** `/decay` proved the shared export parser, aspect frame, metadata validation, and container-based renderer sizing on one Three.js route. The next route needed to exercise different behavior without broadening scope to every visual page.
+
+**Decision:** Wire `/reclamation` as the second pilot with its own `visualExport` metadata, shared export settings parsing, `ExportFrame` framing, mount-container renderer sizing, and a wider camera orbit for narrow aspect ratios. Keep hardware-feed support out of its capability metadata for now.
+
+**Rationale:** Reclamation has a different composition and route-level overlays, including a click-toggled HUD and development recording button. Wiring it next validates that export mode can keep the captured viewport clean while preserving normal route behavior.
+
+---
+
+## 2026-05-08 08:14 PDT - Codex GPT-5
+
+### Decision: Complete v1 as a full visual route fan-out
+
+**Context:** `/decay` and `/reclamation` proved the shared export parser, aspect frame, route metadata, and clean viewport behavior. The remaining visual routes needed the same route contract and operator discoverability to make the registry useful as a production console.
+
+**Decision:** Wire every visual route in the canonical route scope with `visualExport` metadata, `ExportFrame` export mode, mount-container renderer sizing, hidden export-mode controls/overlays, and operator UI surfacing. Keep all routes seed-unsupported. Mark `/broadcast` and `/reclamation` as not hardware-feed-safe; mark the remaining visual routes as hardware-feed-safe after route audit.
+
+**Rationale:** Completing the fan-out makes visual export a consistent platform capability instead of a pilot-only path. Keeping seed support deferred avoids fake determinism, while explicit hardware-feed safety values make operator launch decisions honest.

--- a/feature-dev-docs/feature-dev-visual-export/feature-spec.md
+++ b/feature-dev-docs/feature-dev-visual-export/feature-spec.md
@@ -1,0 +1,121 @@
+# Visual Export Spec
+
+## Purpose
+
+Signal-23 visual routes should operate as reusable visual engines for release assets and live/operator workflows. The public site remains sparse; export capability is exposed through the hidden operator layer and direct soft-secret route URLs.
+
+## Route Scope
+
+Visual export applies to soft-secret visual routes tracked by the operator registry, including `/decay`, `/reclamation`, `/broadcast`, `/forest`, `/stepwell`, `/forbidding`, `/well`, `/tangle`, `/learning`, `/nerve`, `/face`, `/hand`, `/birth`, `/murmur`, `/growth`, and `/resonance`.
+
+This list is the canonical v1 route scope for visual export documentation.
+
+## V1 Implementation
+
+The v1 implementation wires all 16 soft-secret visual routes. It adds shared export settings parsing, an aspect-locked `ExportFrame`, runtime capability validation, visual export metadata for every visual route, and container-based Three.js sizing for the wired routes.
+
+Each route remains normal when opened without a `target` query parameter and enters export mode when `target` is present.
+
+## Export Contract
+
+Routes support normal mode and export mode.
+
+Normal mode:
+
+- The route behaves as it does today.
+- No public navigation or terminal behavior changes.
+- Existing visual framing remains the default.
+
+Export mode:
+
+- The presence of a `target` query parameter is export mode.
+- No `target` query parameter means normal mode.
+- The route is opened with query parameters on the same path.
+- The route reads supported target, seed, duration, and aspect values.
+- The route renders a capture-friendly viewport for the requested target or the route's default target.
+- Unsupported targets always fall back to `defaultTarget`.
+
+Canonical export URL shape:
+
+```text
+/decay?target=canvas&seed=decay-001&duration=8&aspect=9:16
+```
+
+## Export Targets
+
+The current `ExportTarget` union in `src/data/transmissions.ts` includes only `canvas | reel | hardware-feed | still | loop`. Future targets require widening that union before they appear in `supportedTargets`.
+
+`canvas` is a vertical, short, loop-first target for Spotify Canvas. It uses `9:16`, expects 3-8 seconds, and does not require audio.
+
+`reel` is a vertical social clip target for Instagram and TikTok. It uses `9:16`, expects 6-60 seconds, and may use audio when the campaign requires it.
+
+`hardware-feed` is a live browser output target for Evan/operator capture. It defaults to `16:9`, can run indefinitely, and must not require audio or persistent visible controls.
+
+`still` is a single-frame target for cover, press, thumbnail, or post assets. It supports common social and video ratios and provides browser-rendered still source material.
+
+`loop` is a reusable moving background target. It supports `1:1`, `9:16`, and `16:9`, and expects 3-30 seconds.
+
+## Reserved Targets
+
+`youtube`, `story`, and `square` are reserved names for future longform, vertical story, and square social formats. They are not v1 `ExportTarget` values and must not appear in `supportedTargets` until the registry type is widened.
+
+## Metadata Shape
+
+Detailed export capability should be added to visual transmission entries as `visualExport`.
+
+```ts
+export type VisualExportCapability = {
+  supportedTargets: ExportTarget[];
+  defaultTarget: ExportTarget;
+
+  seed: {
+    supported: boolean;
+    defaultMode: 'random' | 'fixed';
+  };
+
+  duration: {
+    supported: boolean;
+    defaultSeconds?: number;
+    minSeconds?: number;
+    maxSeconds?: number;
+  };
+
+  aspectRatios: {
+    supported: Array<'9:16' | '16:9' | '1:1' | '4:5'>;
+    default: '9:16' | '16:9' | '1:1' | '4:5';
+  };
+
+  capture: 'browser-source' | 'external-only';
+
+  hardwareFeedSafe: boolean;
+  operatorNotes?: string;
+};
+```
+
+`seed.supported: true` means the same seed can replay the same output for the same target, aspect, duration, and supported route state. If a route cannot replay a seed, `seed.supported` is `false`.
+
+`capture: browser-source` means the route renders a browser source suitable for external capture. `capture: external-only` means the route is intended for live hardware feed or external capture only.
+
+`/decay` is currently configured with all v1 targets, `defaultTarget: 'canvas'`, `seed.supported: false`, `capture: 'browser-source'`, and `hardwareFeedSafe: true`.
+
+`/reclamation` is currently configured with `canvas`, `reel`, `still`, and `loop`, `defaultTarget: 'canvas'`, `seed.supported: false`, `capture: 'browser-source'`, and `hardwareFeedSafe: false`. Export mode hides its development recording control and click-toggled HUD.
+
+`/broadcast` is configured with `canvas`, `reel`, `still`, and `loop`, `defaultTarget: 'canvas'`, `seed.supported: false`, `capture: 'browser-source'`, and `hardwareFeedSafe: false`.
+
+The remaining visual routes are configured with all v1 targets, `defaultTarget: 'canvas'`, `seed.supported: false`, `capture: 'browser-source'`, and `hardwareFeedSafe: true`.
+
+## Operator UI Implications
+
+`/operator` shows compact export indicators for supported targets and hardware-feed safety.
+
+`/operator/transmissions/:slug` shows detailed visual export capability and preset launch links for visual transmissions.
+
+Operator launch links should open the existing visual route with export query parameters. They should not create new public navigation paths.
+
+## Non-Goals For V1
+
+V1 does not include server-side rendering, video transcoding, automated upload to social platforms, public navigation, authentication, or full analytics/ROI integration.
+
+V1 does not include in-page recording methods, final video/image format promises, or fixed-shape visual control metadata.
+
+V1 does not require every existing visual route to support every export target. Unsupported capabilities are valid when they are explicit and visible to operators.

--- a/feature-dev-docs/feature-dev-visual-export/handoff.md
+++ b/feature-dev-docs/feature-dev-visual-export/handoff.md
@@ -1,0 +1,194 @@
+# Visual Export — Full v1 Fan-Out + Operator UI v2 (Handoff)
+
+Status: executed on 2026-05-08. The current product truth lives in `requirements.md`, `decisions.md`, `tests.md`, and `feature-spec.md`.
+
+You are completing the visual-export feature on the `decay-breathing` branch in one batch. Everything ships in a single PR. This document is self-contained — read it end to end before starting.
+
+## Context
+
+Two routes are already wired with the v1 export pattern: `/decay` and `/reclamation`. The shared infrastructure is in place. This batch fans the same pattern out to the remaining 14 visual routes, adds the operator UI surfacing for export capabilities, and tidies up branch hygiene before the single PR.
+
+Reference docs in this folder define the v1 contract — read them first if anything below is unclear:
+
+- `feature-spec.md` — export contract, target shapes, metadata shape, reserved targets
+- `requirements.md` — capability schema, route-level export behavior, edge cases
+- `decisions.md` — locked architectural decisions
+- `tests.md` — behavior-level acceptance criteria
+
+## What is already done — do not redo
+
+- **Shared infrastructure** (do not modify unless you find a real bug):
+  - `src/lib/exportSettings.ts` — `useExportSettings` hook, `resolveSettings` pure function, `AspectRatio` type
+  - `src/lib/validateVisualExport.ts` — runtime validator
+  - `src/components/ExportFrame/ExportFrame.tsx` + `.css` — aspect-locked framing wrapper
+- **Type added**: `VisualExportCapability` and `ExportAspectRatio` in `src/data/transmissions.ts`
+- **Two routes wired**:
+  - `/decay` → `decayVisualExport`, `hardwareFeedSafe: true`, all 5 targets
+  - `/reclamation` → `reclamationVisualExport`, `hardwareFeedSafe: false`, no `hardware-feed` target
+- **Auto-validation** runs at module load in `transmissions.ts` (don't remove it; extend it for new entries by definition since the loop iterates all transmissions).
+- **Record button convention**: gated `process.env.NODE_ENV !== 'production' && !exportSettings.isExportMode`. Apply this verbatim to every other route that has a record button.
+
+Use Decay (`src/components/Decay/Decay.tsx`) and Reclamation (`src/components/Reclamation/Reclamation.tsx`) as your reference implementations. The pattern is established; do not deviate from it without flagging.
+
+## What to build in this batch
+
+### 1. Wire the 14 remaining visual routes
+
+Routes (all under `src/components/<Name>/<Name>.tsx`):
+
+`/broadcast`, `/forest`, `/stepwell`, `/forbidding` (component name: `ForbiddingBlocks`), `/well`, `/tangle`, `/learning`, `/nerve`, `/face`, `/hand`, `/birth`, `/murmur`, `/growth`, `/resonance`.
+
+For each route, do all of the following:
+
+#### 1a. Add a `<routeName>VisualExport` capability constant
+
+Place near the existing two in `src/data/transmissions.ts`. Use this rubric:
+
+- `supportedTargets`: include all 5 (`canvas`, `reel`, `hardware-feed`, `still`, `loop`) **unless** `hardwareFeedSafe` is `false`, in which case drop `hardware-feed`.
+- `defaultTarget: 'canvas'`.
+- `seed: { supported: false, defaultMode: 'random' }` for **all** routes. Do not retrofit RNG. This is locked.
+- `duration: { supported: true, defaultSeconds: 8, minSeconds: 3, maxSeconds: 30 }` unless the route has a longer natural cycle (meditative/breathing motion → up to 60s max). Pick per route based on observed motion period.
+- `aspectRatios: { supported: ['9:16', '16:9', '1:1', '4:5'], default: '9:16' }`.
+- `capture: 'browser-source'`.
+- `hardwareFeedSafe`: `true` if the route renders a useful visual without any user interaction (load it, walk away, output is still valid). `false` if the visual is essentially empty or broken without clicks (e.g., `/broadcast`'s `spawnRing` — if clicks are required for anything to appear, it's not hardware-feed-safe).
+- `operatorNotes`: one short sentence about non-determinism, warmup time, or any quirk.
+
+#### 1b. Modify the route component
+
+Follow Decay/Reclamation exactly:
+
+- Import `ExportFrame`, the route's `visualExport` constant, and `useExportSettings`.
+- Call `useExportSettings(<routeName>VisualExport)` near the top of the component.
+- Replace `window.innerWidth/innerHeight` reads with the `getMountSize()` pattern:
+  ```ts
+  const getMountSize = () => {
+    const rect = mountElement.getBoundingClientRect();
+    const width = rect.width || mountElement.clientWidth || window.innerWidth;
+    const height = rect.height || mountElement.clientHeight || window.innerHeight;
+    return {
+      width: Math.max(1, Math.floor(width)),
+      height: Math.max(1, Math.floor(height)),
+    };
+  };
+  ```
+- Replace `window.addEventListener('resize', ...)` with `ResizeObserver(resizeToMount)` observing `mountElement`. Disconnect in cleanup.
+- Wrap the return in `<ExportFrame aspect={exportSettings.aspect} active={exportSettings.isExportMode}>`.
+- Effect dep array: `[exportSettings.isExportMode]`.
+- **Container click handlers** (HUD toggles, spawn-on-click): gate on `!exportSettings.isExportMode` so they no-op during export. Pattern:
+  ```tsx
+  onClick={() => { if (!exportSettings.isExportMode) setShowText(prev => !prev); }}
+  ```
+- **Record buttons**: gate on `process.env.NODE_ENV !== 'production' && !exportSettings.isExportMode`. Same as Decay/Reclamation.
+- **HUD/log overlays**: gate visibility on `&& !exportSettings.isExportMode` so they don't appear in the captured viewport.
+- **Three.js framing**: if the scene clips at narrow aspects (9:16), add a camera-distance or orbit-radius tweak similar to Decay's `getCameraBaseZ` or Reclamation's `mountAspect < 0.8 ? 300 : ...`. Verify by loading `?target=canvas` and confirming the subject fits.
+
+#### 1c. Update the route's CSS
+
+If the container is `width: 100vw; height: 100vh`, change to `width: 100%; height: 100%` so it sits inside `<ExportFrame>` cleanly. (Same change already applied to Reclamation.)
+
+#### 1d. Update the existing transmission entry
+
+In `src/data/transmissions.ts`:
+
+- Set `visualExport: <routeName>VisualExport` on the existing transmission entry for that route.
+- Mirror `exportUse` to match `supportedTargets` (manual mirror — denormalized cache pattern).
+
+### 2. Operator UI v2
+
+Add export capability surfacing. Data source is `src/data/transmissions.ts` via the `visualExport` field on each Transmission.
+
+#### `src/components/Operator/OperatorIndex.tsx`
+
+Add an **EXPORT** column to the table. Render per row:
+
+- If `visualExport` is undefined → `—`.
+- Otherwise → comma-separated target IDs (e.g., `canvas, reel, hardware-feed, still, loop`) followed by ` · HFS` if `hardwareFeedSafe: true`.
+
+Hook the new column into whatever search/filter the index already uses; do not redesign the search behavior.
+
+#### `src/components/Operator/TransmissionDetail.tsx`
+
+If the transmission has `visualExport`, add a section after the existing detail rendering. Two sub-sections:
+
+**EXPORT CAPABILITY** (definition list):
+
+- Targets: comma-separated `supportedTargets`
+- Default: `defaultTarget`
+- Aspects: comma-separated `aspectRatios.supported`; mark default with `(default)`
+- Duration: `minSeconds`–`maxSeconds`s (default `defaultSeconds`s) — or `indefinite` if `duration.supported: false`
+- Seed: `supported` or `not supported`
+- Capture: `capture` value
+- Hardware-feed safe: `yes` or `no`
+- Notes: `operatorNotes` if present
+
+**LAUNCH LINKS** (one link per supported target):
+
+- For each target in `supportedTargets`, render a link: `<a href="<route>?target=<target>" target="_blank" rel="noopener">target</a>`.
+- Link opens in new tab.
+- Use the transmission's `route` field for the path.
+
+No new routes. No URL structure changes. Operator UI search/sort/filter behavior unchanged outside of the new column.
+
+### 3. Branch hygiene
+
+- Append to existing `.gitignore`:
+  ```
+  .beads/
+  .claude/
+  docs/plans/
+  ```
+- Do not commit `.beads/issues.jsonl`, `.beads/signal-23-website.db`, `.claude/`, or `docs/plans/`. If they are already tracked, leave them — only add ignore rules going forward.
+
+## Constraints and non-goals
+
+- **No seed support** on any route. v1 is non-deterministic for all 16 routes.
+- **URL contract is locked**: `target` is the export switch; do not introduce `mode=export` or any other signal.
+- **No `addedAt` field** on `VisualExportCapability`.
+- **Do not modify** `exportSettings.ts`, `validateVisualExport.ts`, or `ExportFrame.tsx` unless you find a real bug. Flag any bug rather than silently fixing.
+- **Operator UI**: only add the new column and detail block. Do not change search, filter, sort, navigation, or styling outside of what the new content needs.
+- **Public surface untouched**: do not modify the homepage, terminal command list, sitemap behavior, or public navigation.
+- **No new test infrastructure**. The project has no vitest/jest/playwright wired up. Validation is the runtime validator + manual checklist below.
+
+## Manual verification — complete before declaring done
+
+### Three sample routes — full check
+
+Pick `/broadcast` (likely non-HFS), `/forest` (probably HFS), and `/nerve` (heavy motion + interaction). For each:
+
+1. Load with no params → unchanged behavior, console clean.
+2. Load `?target=canvas` → 9:16 letterboxed, scene framed correctly (no clipping), HUD/record button hidden, click on container is a no-op.
+3. Load `?target=canvas&aspect=16:9` → 16:9 letterboxed, scene reframes (camera adjusts).
+4. Load `?target=youtube` → falls back to canvas, `console.warn` fires.
+
+### Smoke test — remaining 11 routes
+
+For each: load `?target=canvas` and confirm no console errors and the scene renders inside the frame.
+
+### Operator UI
+
+1. `/operator` shows the EXPORT column populated for all 16 visual routes.
+2. `/operator/transmissions/decay` shows full capability block + 5 launch links.
+3. `/operator/transmissions/reclamation` shows 4 launch links (no `hardware-feed`).
+4. Clicking a launch link opens the route in a new tab with the correct query params.
+
+### Public surface
+
+`/` and `/terminal` look identical to before.
+
+### TypeScript
+
+`tsc --noEmit` (or the project's equivalent — check `package.json` scripts) compiles cleanly.
+
+## Final reporting
+
+When done, report back with:
+
+1. **Each route's `hardwareFeedSafe` value** and a one-sentence reason for each (16 lines total, one per visual route).
+2. **Any route where you found a clipping/framing issue** at narrow aspect and what you did to fix it.
+3. **Anything that didn't fit the pattern cleanly** so we can review the exception.
+4. **Confirmation** that the manual verification checklist passed.
+5. **A summary diff** (`git diff --stat`) so we can sanity-check the scope of changes.
+
+## After this batch
+
+Once this PR merges, the visual-export v1 initiative is complete. No further follow-ups are scheduled. The three deferred decisions in `decisions.md` (provenance for `visualExport`, `exportUse` derivation rules, hardware-feed audits) remain deferred — revisit them only if drift or pain shows up in real use.

--- a/feature-dev-docs/feature-dev-visual-export/requirements.md
+++ b/feature-dev-docs/feature-dev-visual-export/requirements.md
@@ -1,0 +1,112 @@
+# Visual Export - Requirements
+
+## Summary
+
+Signal-23 hidden visual routes must become reusable export engines without becoming public navigation. The canonical visual route list lives in `feature-spec.md` under Route Scope.
+
+The v1 export contract supports Spotify Canvas, Instagram/TikTok reels, stills, loops, and Evan's hardware-feed workflow through metadata and route-level export behavior. V1 produces browser-rendered source output for external capture or downstream processing; it does not define in-page recording transports or final transcoded delivery formats.
+
+Visual export v1 applies the contract to all 16 soft-secret visual routes in the operator registry. `/operator` surfaces each route's export capability, and route detail pages expose preset launch links.
+
+## Export Targets
+
+The current `ExportTarget` union in `src/data/transmissions.ts` includes only `canvas | reel | hardware-feed | still | loop`. Future targets require widening that union before they appear in `supportedTargets`.
+
+| Target | Aspect Ratio | Duration | Audio | Output Expectation |
+| --- | --- | --- | --- | --- |
+| `canvas` | `9:16` | 3-8 seconds | Not required | Browser-rendered vertical loop source for downstream Canvas delivery |
+| `reel` | `9:16` | 6-60 seconds | Optional | Browser-rendered vertical clip source for downstream social delivery |
+| `hardware-feed` | `16:9` by default, fullscreen-safe | Operator-set or indefinite | Not required | Live fullscreen browser output for external capture or hardware routing |
+| `still` | `1:1`, `4:5`, `9:16`, or `16:9` | Single frame | Not required | Browser-rendered still frame source |
+| `loop` | `1:1`, `9:16`, or `16:9` | 3-30 seconds | Not required | Browser-rendered moving loop source |
+
+## Visual Capability Metadata
+
+Visual export capability metadata attaches to visual `Transmission` entries in `src/data/transmissions.ts`. Every visual route in the canonical route scope has a `visualExport` object.
+
+```ts
+export type VisualExportCapability = {
+  supportedTargets: ExportTarget[];
+  defaultTarget: ExportTarget;
+
+  seed: {
+    supported: boolean;
+    defaultMode: 'random' | 'fixed';
+  };
+
+  duration: {
+    supported: boolean;
+    defaultSeconds?: number;
+    minSeconds?: number;
+    maxSeconds?: number;
+  };
+
+  aspectRatios: {
+    supported: Array<'9:16' | '16:9' | '1:1' | '4:5'>;
+    default: '9:16' | '16:9' | '1:1' | '4:5';
+  };
+
+  capture: 'browser-source' | 'external-only';
+
+  hardwareFeedSafe: boolean;
+  operatorNotes?: string;
+};
+```
+
+The existing `exportUse` field remains the lightweight registry summary. `visualExport` is the detailed v1 capability object for validation, launch links, operator display, and route export behavior. For wired routes, `exportUse` and `visualExport.supportedTargets` must agree by hand until the source-of-truth decision is resolved.
+
+## Route-Level Export Behavior
+
+Normal route loading must remain unchanged when no `target` query parameter is present. In v1, this behavior is implemented on all visual routes in the canonical route scope.
+
+The presence of `target` is export mode. Export mode is entered through query parameters on the existing soft-secret route, not through a public navigation path. The canonical shape is:
+
+```text
+/decay?target=canvas&seed=decay-001&duration=8&aspect=9:16
+```
+
+Visual routes with `seed.supported: true` must render the same output for the same seed, target, aspect ratio, duration, and supported route state. Routes with `seed.supported: false` must still render successfully and disclose that seed replay is unsupported. `/decay` is explicitly non-deterministic in v1 and keeps its existing random behavior.
+
+Export controls are allowed only outside the captured viewport. Routes with `hardwareFeedSafe: false` may use an in-viewport operator overlay, but that overlay must be removable before final capture.
+
+Unsupported targets always fall back to the route's `defaultTarget`. Unsupported requests must never produce blank screens, broken canvases, or redirects into public navigation.
+
+Hardware-feed-safe routes must keep the captured viewport clean. If an unsupported target is requested on a hardware-feed-safe route, the viewport falls back silently to `defaultTarget`; the unsupported-target message is surfaced through `console.warn` and may also appear in a non-overlay area outside the captured viewport. Non-hardware-feed-safe routes may show an in-viewport unsupported-target overlay.
+
+Routes that use viewport-sized rendering must use their mount container as the authoritative size in export mode. Wired visual routes use an aspect-controlled `ExportFrame` wrapper and a mount-element `ResizeObserver` so Three.js fills the frame rather than the full browser window.
+
+Aspect-framed routes must preserve the intended subject inside the frame. `/decay` adjusts camera distance from the mount aspect ratio for export mode and narrow normal viewports so targets such as `canvas` and mobile portrait previews do not crop the shell edges.
+
+`/reclamation` supports `canvas`, `reel`, `still`, and `loop` exports. It remains seed-unsupported and non-deterministic. Export mode hides the development recording button and click-toggled HUD so the captured viewport stays clean. Narrow aspect ratios use a wider camera orbit to keep the city and bloom structure inside frame.
+
+All v1 visual routes remain seed-unsupported and non-deterministic. `/broadcast` and `/reclamation` are not hardware-feed-safe in v1; the other visual routes expose `hardware-feed` because they render useful unattended visual output and hide controls or HUD overlays in export mode.
+
+The operator index must display an export column sourced from `visualExport`. The operator detail page must display capability metadata and launch links of the form `<route>?target=<target>` for every supported target.
+
+## Constraints
+
+Visual export does not make hidden routes public. The homepage, terminal command list, sitemap behavior, and public navigation remain unchanged.
+
+The browser route is the source visual engine. Any future server processing, transcoding, upload automation, or analytics consumes output from that engine rather than replacing it.
+
+Hardware-feed-safe routes must avoid mandatory pointer interaction, modal UI, unstable frame layout, and controls that remain visible over the output.
+
+## Edge Cases
+
+Routes with `capture: external-only` can still be useful as hardware feeds.
+
+Routes with no duration support can run indefinitely but should still accept target/aspect metadata for framing.
+
+Routes with 3D assets or audio dependencies must expose loading and failure states suitable for export mode.
+
+Mobile export controls must not overlap the visual viewport or prevent the route from being captured.
+
+Desktop export controls must fit without forcing horizontal page overflow.
+
+## User Flows
+
+An operator opens `/operator`, sees which visual routes support each export target, then opens a route detail page for launch links and notes.
+
+An operator opens `/decay?target=canvas&seed=decay-001&duration=8&aspect=9:16`, verifies the framed output, hides any out-of-viewport controls, and records a Canvas-ready source clip externally.
+
+Evan opens a hardware-feed-safe route in fullscreen export mode and sends the clean browser output to external capture or performance hardware.

--- a/feature-dev-docs/feature-dev-visual-export/tests.md
+++ b/feature-dev-docs/feature-dev-visual-export/tests.md
@@ -1,0 +1,114 @@
+# Visual Export - Test Specifications
+
+## Acceptance Criteria
+
+- All 16 visual routes expose complete export capability metadata.
+- Supported target IDs match the shared export target vocabulary.
+- All visual routes open normally with no export parameters.
+- All visual routes can open in export mode through query parameters without public navigation changes.
+- Unsupported export target requests on wired routes render the route's default target without blanking, crashing, or redirecting.
+- Hardware-feed-safe routes keep unsupported-target messages out of the captured viewport.
+- Seed-supported routes render repeatable visual state for the same seed, target, aspect ratio, duration, and supported route state.
+- All visual routes remain seed-unsupported and non-deterministic in v1.
+- Operator index shows visual export target support and hardware-feed safety.
+- Operator detail views show export capability metadata and launch links.
+- Mobile export controls fit without blocking the visual output.
+- Desktop export controls fit without forcing horizontal overflow.
+- The homepage and terminal command directory remain unchanged.
+
+## Unit Test Expectations
+
+Visual export metadata validation should reject unknown target IDs, missing default targets, default targets not included in `supportedTargets`, invalid duration ranges, and invalid aspect ratio defaults.
+
+Route export parsing should produce stable normalized settings from supported query parameters and should ignore or report unsupported parameters without throwing runtime errors.
+
+Seed handling should distinguish seed-supported behavior from seed-unsupported behavior.
+
+Hardware-feed safety should be explicit and boolean for every visual route with detailed export metadata.
+
+The runtime validator should emit no errors for any visual route metadata at module load.
+
+## Integration Paths
+
+Path 1: Normal Decay route
+
+1. Load `/decay`.
+2. Confirm existing visual behavior is unchanged.
+3. Confirm no export frame or letterbox appears.
+4. Confirm portrait mobile viewports such as iPhone SE do not crop the Decay shell edges.
+5. Confirm no unsupported-target console warning appears.
+
+Path 2: Canvas export mode
+
+1. Load `/decay?target=canvas&seed=test-seed&duration=8&aspect=9:16`.
+2. Confirm the route renders in the requested framing.
+3. Confirm the Three.js scene remains visible inside the aspect frame.
+4. Confirm the Decay shell edges are not cropped by the narrow frame.
+5. Confirm no in-viewport controls appear over the export frame.
+
+Path 3: Reclamation canvas export mode
+
+1. Load `/reclamation`.
+2. Confirm existing normal behavior is unchanged, including the click-toggled HUD outside export mode.
+3. Load `/reclamation?target=canvas&duration=12&aspect=9:16`.
+4. Confirm the route renders inside the requested aspect frame.
+5. Confirm the city and bloom structure fit the narrow frame without obvious subject cropping.
+6. Confirm the development recording button and HUD do not appear over the export frame.
+
+Path 4: Unsupported target
+
+1. Load `/decay?target=youtube`.
+2. Confirm the page does not blank, crash, or redirect.
+3. Confirm the route uses its default `canvas` target.
+4. Confirm `console.warn` reports `unsupported target: youtube`.
+5. Repeat for `/reclamation?target=hardware-feed` and confirm the route falls back to its default `canvas` target.
+
+Path 5: Hardware-feed-safe unsupported target
+
+1. Load `/decay?target=youtube`.
+2. Confirm the captured viewport silently falls back to the route's default target.
+3. Confirm the unsupported-target warning is emitted through `console.warn`.
+4. Confirm any visible message appears outside the captured viewport.
+
+Path 6: Fan-out sample routes
+
+1. Load `/broadcast`, `/forest`, and `/nerve` with no query parameters.
+2. Confirm normal visual behavior is preserved.
+3. Load each route with `?target=canvas`.
+4. Confirm each route renders inside a `9:16` export frame with controls and overlays hidden.
+5. Load each route with `?target=canvas&aspect=16:9`.
+6. Confirm each route renders inside a `16:9` export frame.
+7. Load each route with `?target=youtube`.
+8. Confirm each route falls back to its default target without blanking, crashing, or redirecting.
+
+Path 7: Remaining visual route smoke test
+
+1. Load each remaining visual route with `?target=canvas`.
+2. Confirm the scene renders inside the export frame.
+3. Confirm no development recording control or HUD overlay appears over the captured viewport.
+
+Path 8: Operator visibility
+
+1. Load `/operator`.
+2. Confirm the operator index shows an export column populated for all visual routes.
+3. Open `/operator/transmissions/decay`.
+4. Confirm the detail view shows export capability metadata and five launch links.
+5. Open `/operator/transmissions/reclamation`.
+6. Confirm the detail view shows export capability metadata and four launch links.
+
+Path 9: Public surface preservation
+
+1. Load `/`.
+2. Confirm the homepage does not link to export mode or `/operator`.
+3. Load `/terminal` and run the command directory.
+4. Confirm no export or operator command appears unless intentionally introduced by a future documented change.
+
+## Edge Case Tests
+
+Routes with external assets should show export-safe loading and failure states.
+
+Routes with `capture: external-only` should still render correctly for hardware-feed or external capture.
+
+Routes with indefinite duration should not require a duration parameter to render.
+
+Long seed strings and operator notes should wrap without overlapping controls.

--- a/netlify.toml
+++ b/netlify.toml
@@ -25,6 +25,16 @@
     [headers.values]
     Cache-Control = "public, max-age=31536000"
 
+[[headers]]
+  for = "/operator"
+    [headers.values]
+    X-Robots-Tag = "noindex, nofollow"
+
+[[headers]]
+  for = "/operator/*"
+    [headers.values]
+    X-Robots-Tag = "noindex, nofollow"
+
 [[redirects]]
   from = "/*"
   to = "/index.html"

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,3 @@
+User-agent: *
+Disallow: /operator
+Disallow: /operator/

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -29,6 +29,8 @@ import { Birth } from './components/Birth/Birth';
 import { Murmur } from './components/Murmur/Murmur';
 import { Decay } from './components/Decay/Decay';
 import { Reclamation } from './components/Reclamation/Reclamation';
+import { OperatorIndex } from './components/Operator/OperatorIndex';
+import { TransmissionDetail } from './components/Operator/TransmissionDetail';
 
 
 
@@ -186,6 +188,8 @@ const App = () => {
           <Route path="/murmur" element={<Murmur />} />
           <Route path="/decay" element={<Decay />} />
           <Route path="/reclamation" element={<Reclamation />} />
+          <Route path="/operator" element={<OperatorIndex />} />
+          <Route path="/operator/transmissions/:slug" element={<TransmissionDetail />} />
         </Routes>
       </WorkstationShell>
     </BrowserRouter>

--- a/src/components/Birth/Birth.tsx
+++ b/src/components/Birth/Birth.tsx
@@ -5,10 +5,14 @@ import { EffectComposer } from 'three/examples/jsm/postprocessing/EffectComposer
 import { RenderPass } from 'three/examples/jsm/postprocessing/RenderPass';
 import { UnrealBloomPass } from 'three/examples/jsm/postprocessing/UnrealBloomPass';
 import { ShaderPass } from 'three/examples/jsm/postprocessing/ShaderPass';
+import { ExportFrame } from '../ExportFrame/ExportFrame';
+import { birthVisualExport } from '../../data/transmissions';
+import { useExportSettings } from '../../lib/exportSettings';
 import './Birth.css';
 
 export const Birth: React.FC = () => {
     const mountRef = useRef<HTMLDivElement>(null);
+    const exportSettings = useExportSettings(birthVisualExport);
     const [isRecording, setIsRecording] = useState(false);
     const [recordingTime, setRecordingTime] = useState(0);
     const mediaRecorderRef = useRef<MediaRecorder | null>(null);
@@ -60,6 +64,21 @@ export const Birth: React.FC = () => {
 
     useEffect(() => {
         if (!mountRef.current) return;
+        const mountElement = mountRef.current;
+
+        const getMountSize = () => {
+            const rect = mountElement.getBoundingClientRect();
+            const width = rect.width || mountElement.clientWidth || window.innerWidth;
+            const height = rect.height || mountElement.clientHeight || window.innerHeight;
+
+            return {
+                width: Math.max(1, Math.floor(width)),
+                height: Math.max(1, Math.floor(height)),
+            };
+        };
+
+        const initialSize = getMountSize();
+        let mountAspect = initialSize.width / initialSize.height;
 
         let abortController = new AbortController();
         let loadedGltf: any = null;
@@ -68,15 +87,15 @@ export const Birth: React.FC = () => {
         const scene = new THREE.Scene();
         scene.fog = new THREE.FogExp2(0x000000, 0.035);
 
-        const camera = new THREE.PerspectiveCamera(50, window.innerWidth / window.innerHeight, 0.1, 1000);
-        camera.position.z = 6;
+        const camera = new THREE.PerspectiveCamera(50, mountAspect, 0.1, 1000);
+        camera.position.z = mountAspect < 0.8 ? 8 : 6;
 
         const renderer = new THREE.WebGLRenderer({ antialias: true, alpha: true });
-        renderer.setSize(window.innerWidth, window.innerHeight);
+        renderer.setSize(initialSize.width, initialSize.height);
         renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
         renderer.toneMapping = THREE.ReinhardToneMapping;
         renderer.toneMappingExposure = 1.2;
-        mountRef.current.appendChild(renderer.domElement);
+        mountElement.appendChild(renderer.domElement);
         canvasRef.current = renderer.domElement;
 
         // Post-processing
@@ -84,7 +103,7 @@ export const Birth: React.FC = () => {
         composer.addPass(new RenderPass(scene, camera));
 
         const bloomPass = new UnrealBloomPass(
-            new THREE.Vector2(window.innerWidth, window.innerHeight),
+            new THREE.Vector2(initialSize.width, initialSize.height),
             1.8,   // strength - strong atmospheric glow
             0.9,   // radius - wide, soft spread
             0.15   // threshold - low so even dim elements bloom
@@ -133,6 +152,17 @@ export const Birth: React.FC = () => {
         });
         composer.addPass(grainPass);
 
+        const resizeToMount = () => {
+            const { width, height } = getMountSize();
+            mountAspect = width / height;
+            camera.aspect = mountAspect;
+            camera.position.z = mountAspect < 0.8 ? 8 : 6;
+            camera.updateProjectionMatrix();
+            renderer.setSize(width, height);
+            composer.setSize(width, height);
+            bloomPass.resolution.set(width, height);
+        };
+
         const handleContextLost = (event: Event) => {
             event.preventDefault();
             console.warn('WebGL context lost');
@@ -141,8 +171,7 @@ export const Birth: React.FC = () => {
 
         const handleContextRestored = () => {
             console.log('WebGL context restored');
-            renderer.setSize(window.innerWidth, window.innerHeight);
-            composer.setSize(window.innerWidth, window.innerHeight);
+            resizeToMount();
             if (!animationId && isComponentMounted) animate();
         };
 
@@ -467,20 +496,16 @@ export const Birth: React.FC = () => {
             composer.render();
         };
 
-        const handleResize = () => {
-            camera.aspect = window.innerWidth / window.innerHeight;
-            camera.updateProjectionMatrix();
-            renderer.setSize(window.innerWidth, window.innerHeight);
-            composer.setSize(window.innerWidth, window.innerHeight);
-            bloomPass.resolution.set(window.innerWidth, window.innerHeight);
-        };
-        window.addEventListener('resize', handleResize);
+        resizeToMount();
+
+        const resizeObserver = new ResizeObserver(resizeToMount);
+        resizeObserver.observe(mountElement);
 
         return () => {
             isComponentMounted = false;
             abortController.abort();
             if (animationId) cancelAnimationFrame(animationId);
-            window.removeEventListener('resize', handleResize);
+            resizeObserver.disconnect();
 
             // Dispose post-processing
             composer.dispose();
@@ -499,29 +524,31 @@ export const Birth: React.FC = () => {
 
             renderer.dispose();
             if (loadedGltf) { /* dispose traversal */ }
-            if (mountRef.current && renderer.domElement) {
-                if (mountRef.current.contains(renderer.domElement)) {
-                    mountRef.current.removeChild(renderer.domElement);
+            if (mountElement && renderer.domElement) {
+                if (mountElement.contains(renderer.domElement)) {
+                    mountElement.removeChild(renderer.domElement);
                 }
             }
         };
-    }, []);
+    }, [exportSettings.isExportMode]);
 
     return (
-        <div className="birth-container">
-            <div ref={mountRef} className="birth-canvas" />
-            {process.env.NODE_ENV !== 'production' && (
-                <button
-                    className={`record-button ${isRecording ? 'recording' : ''}`}
-                    onClick={toggleRecording}
-                    title={isRecording ? 'Stop Recording' : 'Start Recording'}
-                >
-                    <span className="record-icon" />
-                    {isRecording && <span className="record-time">
-                        {Math.floor(recordingTime / 60)}:{(recordingTime % 60).toString().padStart(2, '0')}
-                    </span>}
-                </button>
-            )}
-        </div>
+        <ExportFrame aspect={exportSettings.aspect} active={exportSettings.isExportMode}>
+            <div className="birth-container">
+                <div ref={mountRef} className="birth-canvas" />
+                {process.env.NODE_ENV !== 'production' && !exportSettings.isExportMode && (
+                    <button
+                        className={`record-button ${isRecording ? 'recording' : ''}`}
+                        onClick={toggleRecording}
+                        title={isRecording ? 'Stop Recording' : 'Start Recording'}
+                    >
+                        <span className="record-icon" />
+                        {isRecording && <span className="record-time">
+                            {Math.floor(recordingTime / 60)}:{(recordingTime % 60).toString().padStart(2, '0')}
+                        </span>}
+                    </button>
+                )}
+            </div>
+        </ExportFrame>
     );
 };

--- a/src/components/Broadcast/Broadcast.tsx
+++ b/src/components/Broadcast/Broadcast.tsx
@@ -11,6 +11,9 @@ import { WaveRingSystem } from './WaveRingSystem';
 import { NumbersStation } from './NumbersStation';
 import { BroadcastPostShader } from './BroadcastPostShader';
 import { RingParams } from './types';
+import { ExportFrame } from '../ExportFrame/ExportFrame';
+import { broadcastVisualExport } from '../../data/transmissions';
+import { useExportSettings } from '../../lib/exportSettings';
 
 
 
@@ -29,6 +32,7 @@ const dataPayloads = [
 
 const Broadcast: React.FC = () => {
     const containerRef = useRef<HTMLDivElement>(null);
+    const exportSettings = useExportSettings(broadcastVisualExport);
     const clockRef = useRef(new THREE.Clock());
     const [rings, setRings] = useState<RingParams[]>([]);
     const stateRef = useRef({
@@ -39,24 +43,43 @@ const Broadcast: React.FC = () => {
     const systems = useMemo(() => ({
         ringSystem: new WaveRingSystem(),
         audioSystem: new NumbersStation(),
-    }), []);
+    }), [exportSettings.isExportMode]);
 
     useEffect(() => {
         if (!containerRef.current) return;
+        const mountElement = containerRef.current;
+
+        const getMountSize = () => {
+            const rect = mountElement.getBoundingClientRect();
+            const width = rect.width || mountElement.clientWidth || window.innerWidth;
+            const height = rect.height || mountElement.clientHeight || window.innerHeight;
+
+            return {
+                width: Math.max(1, Math.floor(width)),
+                height: Math.max(1, Math.floor(height)),
+            };
+        };
+
+        const initialSize = getMountSize();
 
         // SCENE SETUP
         const scene = new THREE.Scene();
         scene.background = new THREE.Color(0x000000);
         scene.fog = new THREE.Fog(0x000000, 5, 50);
 
-        const camera = new THREE.PerspectiveCamera(75, window.innerWidth / window.innerHeight, 0.1, 1000);
+        const camera = new THREE.PerspectiveCamera(
+            75,
+            initialSize.width / initialSize.height,
+            0.1,
+            1000
+        );
         camera.position.set(0, 5, 20);
         camera.lookAt(0, 8, 0);
 
         const renderer = new THREE.WebGLRenderer({ antialias: true, alpha: true });
-        renderer.setSize(window.innerWidth, window.innerHeight);
+        renderer.setSize(initialSize.width, initialSize.height);
         renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
-        containerRef.current.appendChild(renderer.domElement);
+        mountElement.appendChild(renderer.domElement);
 
         // TOWER
         const tower = createTowerGeometry();
@@ -82,7 +105,7 @@ const Broadcast: React.FC = () => {
         composer.addPass(new RenderPass(scene, camera));
 
         const bloomPass = new UnrealBloomPass(
-            new THREE.Vector2(window.innerWidth, window.innerHeight),
+            new THREE.Vector2(initialSize.width, initialSize.height),
             0.6, 0.4, 0.85
         );
         composer.addPass(bloomPass);
@@ -92,7 +115,7 @@ const Broadcast: React.FC = () => {
 
 
         // ANIMATION LOOP
-        const isMobileRef = { current: window.innerWidth < 768 };
+        const isMobileRef = { current: initialSize.width < 768 };
         let animationId: number;
 
         const animate = () => {
@@ -131,19 +154,23 @@ const Broadcast: React.FC = () => {
 
         animate();
 
-        const handleResize = () => {
-            isMobileRef.current = window.innerWidth < 768;
-            camera.aspect = window.innerWidth / window.innerHeight;
+        const resizeToMount = () => {
+            const { width, height } = getMountSize();
+            isMobileRef.current = width < 768;
+            camera.aspect = width / height;
             camera.updateProjectionMatrix();
 
-            renderer.setSize(window.innerWidth, window.innerHeight);
-            composer.setSize(window.innerWidth, window.innerHeight);
+            renderer.setSize(width, height);
+            composer.setSize(width, height);
         };
-        window.addEventListener('resize', handleResize);
+        resizeToMount();
+
+        const resizeObserver = new ResizeObserver(resizeToMount);
+        resizeObserver.observe(mountElement);
 
         return () => {
             cancelAnimationFrame(animationId);
-            window.removeEventListener('resize', handleResize);
+            resizeObserver.disconnect();
 
             // Kill any active gsap animations
             gsap.killTweensOf(systems.ringSystem);
@@ -172,8 +199,11 @@ const Broadcast: React.FC = () => {
             composer.dispose();
             renderer.dispose();
             systems.audioSystem.stop();
+            if (mountElement.contains(renderer.domElement)) {
+                mountElement.removeChild(renderer.domElement);
+            }
         };
-    }, [systems]);
+    }, [systems, exportSettings.isExportMode]);
 
     const spawnRing = async () => {
         if (stateRef.current.audioPaused) {
@@ -208,12 +238,18 @@ const Broadcast: React.FC = () => {
     };
 
     return (
-        <div
-            ref={containerRef}
-            style={{ width: '100%', height: '100vh', background: 'black', overflow: 'hidden', position: 'relative' }}
-            onClick={spawnRing}
-        >
-        </div>
+        <ExportFrame aspect={exportSettings.aspect} active={exportSettings.isExportMode}>
+            <div
+                ref={containerRef}
+                style={{ width: '100%', height: '100%', background: 'black', overflow: 'hidden', position: 'relative' }}
+                onClick={() => {
+                    if (!exportSettings.isExportMode) {
+                        spawnRing();
+                    }
+                }}
+            >
+            </div>
+        </ExportFrame>
     );
 };
 

--- a/src/components/Decay/Decay.tsx
+++ b/src/components/Decay/Decay.tsx
@@ -4,6 +4,9 @@ import { EffectComposer } from 'three/examples/jsm/postprocessing/EffectComposer
 import { RenderPass } from 'three/examples/jsm/postprocessing/RenderPass';
 import { UnrealBloomPass } from 'three/examples/jsm/postprocessing/UnrealBloomPass';
 import { ShaderPass } from 'three/examples/jsm/postprocessing/ShaderPass';
+import { ExportFrame } from '../ExportFrame/ExportFrame';
+import { decayVisualExport } from '../../data/transmissions';
+import { useExportSettings } from '../../lib/exportSettings';
 import './Decay.css';
 
 // ── Shell constants ──────────────────────────────────────────────────────────
@@ -11,6 +14,25 @@ const OUTER_RADIUS = 2.6;
 const INNER_RADIUS = 2.1;
 const SUBDIVISIONS = 3;
 const PARTICLE_COUNT = 260;
+const CAMERA_FOV = 50;
+const BASE_CAMERA_Z = 7.2;
+const EXPORT_FRAMING_RADIUS = OUTER_RADIUS * 1.16;
+const EXPORT_CAMERA_MOTION_ALLOWANCE = 0.75;
+const NARROW_VIEWPORT_FIT_THRESHOLD = 1;
+
+const getCameraBaseZ = (aspect: number, isExportMode: boolean) => {
+    const shouldFitSubject = isExportMode || aspect < NARROW_VIEWPORT_FIT_THRESHOLD;
+
+    if (!shouldFitSubject) {
+        return BASE_CAMERA_Z;
+    }
+
+    const verticalHalfFov = THREE.MathUtils.degToRad(CAMERA_FOV / 2);
+    const verticalDistance = EXPORT_FRAMING_RADIUS / Math.tan(verticalHalfFov);
+    const horizontalDistance = EXPORT_FRAMING_RADIUS / (Math.tan(verticalHalfFov) * aspect);
+
+    return Math.max(BASE_CAMERA_Z, verticalDistance, horizontalDistance) + EXPORT_CAMERA_MOTION_ALLOWANCE;
+};
 
 interface Fragment {
     homeA: THREE.Vector3;
@@ -60,6 +82,7 @@ function buildFragments(geometry: THREE.BufferGeometry): Fragment[] {
 
 export const Decay: React.FC = () => {
     const mountRef = useRef<HTMLDivElement>(null);
+    const exportSettings = useExportSettings(decayVisualExport);
     const [isRecording, setIsRecording] = useState(false);
     const [recordingTime, setRecordingTime] = useState(0);
     const mediaRecorderRef = useRef<MediaRecorder | null>(null);
@@ -122,41 +145,50 @@ export const Decay: React.FC = () => {
     useEffect(() => {
         if (!mountRef.current) return;
         let isComponentMounted = true;
+        const mountElement = mountRef.current;
+
+        const getMountSize = () => {
+            const rect = mountElement.getBoundingClientRect();
+            const width = rect.width || mountElement.clientWidth || window.innerWidth;
+            const height = rect.height || mountElement.clientHeight || window.innerHeight;
+
+            return {
+                width: Math.max(1, Math.floor(width)),
+                height: Math.max(1, Math.floor(height)),
+            };
+        };
+
+        const initialSize = getMountSize();
 
         // ── Scene ────────────────────────────────────────────────────────
         const scene = new THREE.Scene();
         scene.fog = new THREE.FogExp2(0x000000, 0.025);
 
         const camera = new THREE.PerspectiveCamera(
-            50,
-            window.innerWidth / window.innerHeight,
+            CAMERA_FOV,
+            initialSize.width / initialSize.height,
             0.1,
             1000
         );
-        camera.position.z = 7.2;
+        let cameraBaseZ = getCameraBaseZ(camera.aspect, exportSettings.isExportMode);
+        camera.position.z = cameraBaseZ;
 
         const renderer = new THREE.WebGLRenderer({ antialias: true, alpha: true });
-        renderer.setSize(window.innerWidth, window.innerHeight);
+        renderer.setSize(initialSize.width, initialSize.height);
         renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
         renderer.toneMapping = THREE.ReinhardToneMapping;
         renderer.toneMappingExposure = 1.05;
-        mountRef.current.appendChild(renderer.domElement);
+        mountElement.appendChild(renderer.domElement);
         canvasRef.current = renderer.domElement;
 
         const handleContextLost = (event: Event) => event.preventDefault();
-        const handleContextRestored = () => {
-            renderer.setSize(window.innerWidth, window.innerHeight);
-            composer.setSize(window.innerWidth, window.innerHeight);
-        };
-        renderer.domElement.addEventListener('webglcontextlost', handleContextLost);
-        renderer.domElement.addEventListener('webglcontextrestored', handleContextRestored);
 
         // ── Post-processing ──────────────────────────────────────────────
         const composer = new EffectComposer(renderer);
         composer.addPass(new RenderPass(scene, camera));
 
         const bloomPass = new UnrealBloomPass(
-            new THREE.Vector2(window.innerWidth, window.innerHeight),
+            new THREE.Vector2(initialSize.width, initialSize.height),
             0.8,
             0.55,
             0.22
@@ -380,14 +412,26 @@ export const Decay: React.FC = () => {
         const _v = new THREE.Vector3();
 
         // ── Resize handling ──────────────────────────────────────────────
-        const handleResize = () => {
-            camera.aspect = window.innerWidth / window.innerHeight;
+        const resizeToMount = () => {
+            const { width, height } = getMountSize();
+            camera.aspect = width / height;
+            cameraBaseZ = getCameraBaseZ(camera.aspect, exportSettings.isExportMode);
             camera.updateProjectionMatrix();
-            renderer.setSize(window.innerWidth, window.innerHeight);
-            composer.setSize(window.innerWidth, window.innerHeight);
-            bloomPass.resolution.set(window.innerWidth, window.innerHeight);
+            renderer.setSize(width, height);
+            composer.setSize(width, height);
+            bloomPass.resolution.set(width, height);
         };
-        window.addEventListener('resize', handleResize);
+
+        const handleContextRestored = () => {
+            resizeToMount();
+        };
+        renderer.domElement.addEventListener('webglcontextlost', handleContextLost);
+        renderer.domElement.addEventListener('webglcontextrestored', handleContextRestored);
+
+        resizeToMount();
+
+        const resizeObserver = new ResizeObserver(resizeToMount);
+        resizeObserver.observe(mountElement);
 
         // ── Animation loop ───────────────────────────────────────────────
         let animationId = 0;
@@ -504,7 +548,7 @@ export const Decay: React.FC = () => {
 
             camera.position.x = Math.sin(time * 0.08) * 0.25 + shakeX;
             camera.position.y = Math.cos(time * 0.06) * 0.2 + shakeY;
-            camera.position.z = 7.2 - panicLevel * 0.55 - avgStress * 0.3;
+            camera.position.z = cameraBaseZ - panicLevel * 0.55 - avgStress * 0.3;
             camera.lookAt(0, 0, 0);
 
             // ── Dust drift ───────────────────────────────────────────────
@@ -532,7 +576,7 @@ export const Decay: React.FC = () => {
         return () => {
             isComponentMounted = false;
             if (animationId) cancelAnimationFrame(animationId);
-            window.removeEventListener('resize', handleResize);
+            resizeObserver.disconnect();
             renderer.domElement.removeEventListener('webglcontextlost', handleContextLost);
             renderer.domElement.removeEventListener('webglcontextrestored', handleContextRestored);
             composer.dispose();
@@ -548,33 +592,35 @@ export const Decay: React.FC = () => {
             dustSprite.dispose();
             renderer.dispose();
             if (
-                mountRef.current &&
+                mountElement &&
                 renderer.domElement &&
-                mountRef.current.contains(renderer.domElement)
+                mountElement.contains(renderer.domElement)
             ) {
-                mountRef.current.removeChild(renderer.domElement);
+                mountElement.removeChild(renderer.domElement);
             }
         };
-    }, []);
+    }, [exportSettings.isExportMode]);
 
     return (
-        <div className="decay-container">
-            <div ref={mountRef} className="decay-canvas" />
-            {process.env.NODE_ENV !== 'production' && (
-                <button
-                    className={`record-button ${isRecording ? 'recording' : ''}`}
-                    onClick={toggleRecording}
-                    title={isRecording ? 'Stop Recording' : 'Start Recording'}
-                >
-                    <span className="record-icon" />
-                    {isRecording && (
-                        <span className="record-time">
-                            {Math.floor(recordingTime / 60)}:
-                            {(recordingTime % 60).toString().padStart(2, '0')}
-                        </span>
-                    )}
-                </button>
-            )}
-        </div>
+        <ExportFrame aspect={exportSettings.aspect} active={exportSettings.isExportMode}>
+            <div className="decay-container">
+                <div ref={mountRef} className="decay-canvas" />
+                {process.env.NODE_ENV !== 'production' && !exportSettings.isExportMode && (
+                    <button
+                        className={`record-button ${isRecording ? 'recording' : ''}`}
+                        onClick={toggleRecording}
+                        title={isRecording ? 'Stop Recording' : 'Start Recording'}
+                    >
+                        <span className="record-icon" />
+                        {isRecording && (
+                            <span className="record-time">
+                                {Math.floor(recordingTime / 60)}:
+                                {(recordingTime % 60).toString().padStart(2, '0')}
+                            </span>
+                        )}
+                    </button>
+                )}
+            </div>
+        </ExportFrame>
     );
 };

--- a/src/components/ExportFrame/ExportFrame.css
+++ b/src/components/ExportFrame/ExportFrame.css
@@ -1,0 +1,77 @@
+.export-frame-normal {
+  width: 100%;
+  height: 100%;
+}
+
+.export-frame-active {
+  position: fixed;
+  inset: 0;
+  z-index: 0;
+  display: grid;
+  place-items: center;
+  width: 100vw;
+  height: 100dvh;
+  overflow: hidden;
+  background: #000;
+}
+
+.export-frame-canvas {
+  width: 100vw;
+  height: 100dvh;
+  max-width: 100vw;
+  max-height: 100dvh;
+  overflow: hidden;
+  background: #000;
+}
+
+.export-frame-aspect-9-16 {
+  aspect-ratio: 9 / 16;
+  width: auto;
+  height: 100dvh;
+}
+
+.export-frame-aspect-16-9 {
+  aspect-ratio: 16 / 9;
+  width: 100vw;
+  height: auto;
+}
+
+.export-frame-aspect-1-1 {
+  aspect-ratio: 1 / 1;
+  width: min(100vw, 100dvh);
+  height: auto;
+}
+
+.export-frame-aspect-4-5 {
+  aspect-ratio: 4 / 5;
+  width: auto;
+  height: 100dvh;
+}
+
+@media (max-aspect-ratio: 9 / 16) {
+  .export-frame-aspect-9-16 {
+    width: 100vw;
+    height: auto;
+  }
+}
+
+@media (max-aspect-ratio: 4 / 5) {
+  .export-frame-aspect-4-5 {
+    width: 100vw;
+    height: auto;
+  }
+}
+
+@media (max-aspect-ratio: 16 / 9) {
+  .export-frame-aspect-16-9 {
+    width: 100vw;
+    height: auto;
+  }
+}
+
+@media (min-aspect-ratio: 16 / 9) {
+  .export-frame-aspect-16-9 {
+    width: auto;
+    height: 100dvh;
+  }
+}

--- a/src/components/ExportFrame/ExportFrame.tsx
+++ b/src/components/ExportFrame/ExportFrame.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import type { AspectRatio } from '../../lib/exportSettings';
+import './ExportFrame.css';
+
+type ExportFrameProps = {
+  aspect: AspectRatio;
+  active: boolean;
+  children: React.ReactNode;
+};
+
+const aspectClassByRatio: Record<AspectRatio, string> = {
+  '9:16': 'export-frame-aspect-9-16',
+  '16:9': 'export-frame-aspect-16-9',
+  '1:1': 'export-frame-aspect-1-1',
+  '4:5': 'export-frame-aspect-4-5',
+};
+
+export const ExportFrame: React.FC<ExportFrameProps> = ({ aspect, active, children }) => {
+  if (!active) {
+    return <div className="export-frame-normal">{children}</div>;
+  }
+
+  return (
+    <div className="export-frame-active">
+      <div className={`export-frame-canvas ${aspectClassByRatio[aspect]}`}>
+        {children}
+      </div>
+    </div>
+  );
+};

--- a/src/components/Face/Face.tsx
+++ b/src/components/Face/Face.tsx
@@ -1,10 +1,14 @@
 import React, { useEffect, useRef, useState } from 'react';
 import * as THREE from 'three';
 import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader';
+import { ExportFrame } from '../ExportFrame/ExportFrame';
+import { faceVisualExport } from '../../data/transmissions';
+import { useExportSettings } from '../../lib/exportSettings';
 import './Face.css';
 
 export const Face: React.FC = () => {
     const mountRef = useRef<HTMLDivElement>(null);
+    const exportSettings = useExportSettings(faceVisualExport);
     const [isRecording, setIsRecording] = useState(false);
     const [recordingTime, setRecordingTime] = useState(0);
     const mediaRecorderRef = useRef<MediaRecorder | null>(null);
@@ -57,6 +61,21 @@ export const Face: React.FC = () => {
 
     useEffect(() => {
         if (!mountRef.current) return;
+        const mountElement = mountRef.current;
+
+        const getMountSize = () => {
+            const rect = mountElement.getBoundingClientRect();
+            const width = rect.width || mountElement.clientWidth || window.innerWidth;
+            const height = rect.height || mountElement.clientHeight || window.innerHeight;
+
+            return {
+                width: Math.max(1, Math.floor(width)),
+                height: Math.max(1, Math.floor(height)),
+            };
+        };
+
+        const initialSize = getMountSize();
+        let mountAspect = initialSize.width / initialSize.height;
 
         // Track resources for cleanup
         let abortController = new AbortController();
@@ -66,14 +85,23 @@ export const Face: React.FC = () => {
         const scene = new THREE.Scene();
         scene.fog = new THREE.FogExp2(0x000000, 0.015);
 
-        const camera = new THREE.PerspectiveCamera(50, window.innerWidth / window.innerHeight, 0.1, 1000);
-        camera.position.z = 5;  // Pulled back a bit more
+        const camera = new THREE.PerspectiveCamera(50, mountAspect, 0.1, 1000);
+        camera.position.z = mountAspect < 0.8 ? 7 : 5;  // Pulled back a bit more
 
         const renderer = new THREE.WebGLRenderer({ antialias: true, alpha: true });
-        renderer.setSize(window.innerWidth, window.innerHeight);
+        renderer.setSize(initialSize.width, initialSize.height);
         renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
-        mountRef.current.appendChild(renderer.domElement);
+        mountElement.appendChild(renderer.domElement);
         canvasRef.current = renderer.domElement;
+
+        const resizeToMount = () => {
+            const { width, height } = getMountSize();
+            mountAspect = width / height;
+            camera.aspect = mountAspect;
+            camera.position.z = mountAspect < 0.8 ? 7 : 5;
+            camera.updateProjectionMatrix();
+            renderer.setSize(width, height);
+        };
 
         // Handle WebGL context loss
         const handleContextLost = (event: Event) => {
@@ -84,7 +112,7 @@ export const Face: React.FC = () => {
 
         const handleContextRestored = () => {
             console.log('WebGL context restored');
-            renderer.setSize(window.innerWidth, window.innerHeight);
+            resizeToMount();
             if (!animationId && isComponentMounted) animate();
         };
 
@@ -368,17 +396,10 @@ export const Face: React.FC = () => {
 
         // Don't start animation yet - wait for model to load
 
-        // Throttled resize handler
-        let resizeTimeout: NodeJS.Timeout | null = null;
-        const handleResize = () => {
-            if (resizeTimeout) clearTimeout(resizeTimeout);
-            resizeTimeout = setTimeout(() => {
-                camera.aspect = window.innerWidth / window.innerHeight;
-                camera.updateProjectionMatrix();
-                renderer.setSize(window.innerWidth, window.innerHeight);
-            }, 150); // Throttle to max once per 150ms
-        };
-        window.addEventListener('resize', handleResize);
+        resizeToMount();
+
+        const resizeObserver = new ResizeObserver(resizeToMount);
+        resizeObserver.observe(mountElement);
 
         return () => {
             // Mark component as unmounted
@@ -390,9 +411,6 @@ export const Face: React.FC = () => {
             // Stop animation
             if (animationId) cancelAnimationFrame(animationId);
 
-            // Clear resize timeout
-            if (resizeTimeout) clearTimeout(resizeTimeout);
-
             // Stop recording if active
             if (recordingIntervalRef.current) {
                 clearInterval(recordingIntervalRef.current);
@@ -403,7 +421,7 @@ export const Face: React.FC = () => {
             }
 
             // Remove event listeners
-            window.removeEventListener('resize', handleResize);
+            resizeObserver.disconnect();
             renderer.domElement.removeEventListener('webglcontextlost', handleContextLost);
             renderer.domElement.removeEventListener('webglcontextrestored', handleContextRestored);
 
@@ -434,8 +452,8 @@ export const Face: React.FC = () => {
             }
 
             // Remove renderer from DOM
-            if (mountRef.current && renderer.domElement && mountRef.current.contains(renderer.domElement)) {
-                mountRef.current.removeChild(renderer.domElement);
+            if (mountElement && renderer.domElement && mountElement.contains(renderer.domElement)) {
+                mountElement.removeChild(renderer.domElement);
             }
 
             // Dispose all geometries and materials
@@ -457,25 +475,27 @@ export const Face: React.FC = () => {
             // Clear recording chunks
             chunksRef.current = [];
         };
-    }, []);
+    }, [exportSettings.isExportMode]);
 
     return (
-        <div className="face-container">
-            <div ref={mountRef} className="face-canvas" />
+        <ExportFrame aspect={exportSettings.aspect} active={exportSettings.isExportMode}>
+            <div className="face-container">
+                <div ref={mountRef} className="face-canvas" />
 
-            {/* Record Button */}
-            {process.env.NODE_ENV !== 'production' && (
-                <button
-                    className={`record-button ${isRecording ? 'recording' : ''}`}
-                    onClick={toggleRecording}
-                    title={isRecording ? 'Stop Recording' : 'Start Recording'}
-                >
-                    <span className="record-icon" />
-                    {isRecording && <span className="record-time">
-                        {Math.floor(recordingTime / 60)}:{(recordingTime % 60).toString().padStart(2, '0')}
-                    </span>}
-                </button>
-            )}
-        </div>
+                {/* Record Button */}
+                {process.env.NODE_ENV !== 'production' && !exportSettings.isExportMode && (
+                    <button
+                        className={`record-button ${isRecording ? 'recording' : ''}`}
+                        onClick={toggleRecording}
+                        title={isRecording ? 'Stop Recording' : 'Start Recording'}
+                    >
+                        <span className="record-icon" />
+                        {isRecording && <span className="record-time">
+                            {Math.floor(recordingTime / 60)}:{(recordingTime % 60).toString().padStart(2, '0')}
+                        </span>}
+                    </button>
+                )}
+            </div>
+        </ExportFrame>
     );
 };

--- a/src/components/ForbiddingBlocks/ForbiddingBlocks.css
+++ b/src/components/ForbiddingBlocks/ForbiddingBlocks.css
@@ -1,6 +1,7 @@
 .forbidding-container {
-    position: absolute;
-    inset: 0;
+    position: relative;
+    width: 100%;
+    height: 100%;
     background-color: #000;
     overflow: hidden;
     color: #fff;

--- a/src/components/ForbiddingBlocks/ForbiddingBlocks.tsx
+++ b/src/components/ForbiddingBlocks/ForbiddingBlocks.tsx
@@ -1,9 +1,13 @@
 import React, { useEffect, useRef, useState } from 'react';
 import * as THREE from 'three';
+import { ExportFrame } from '../ExportFrame/ExportFrame';
+import { forbiddingVisualExport } from '../../data/transmissions';
+import { useExportSettings } from '../../lib/exportSettings';
 import './ForbiddingBlocks.css';
 
 export const ForbiddingBlocks: React.FC = () => {
     const mountRef = useRef<HTMLDivElement>(null);
+    const exportSettings = useExportSettings(forbiddingVisualExport);
 
     // Recording state
     const [isRecording, setIsRecording] = useState(false);
@@ -74,19 +78,30 @@ export const ForbiddingBlocks: React.FC = () => {
 
     useEffect(() => {
         if (!mountRef.current) return;
+        const mountElement = mountRef.current;
 
-        const width = mountRef.current.clientWidth || window.innerWidth;
-        const height = mountRef.current.clientHeight || window.innerHeight;
+        const getMountSize = () => {
+            const rect = mountElement.getBoundingClientRect();
+            const width = rect.width || mountElement.clientWidth || window.innerWidth;
+            const height = rect.height || mountElement.clientHeight || window.innerHeight;
+
+            return {
+                width: Math.max(1, Math.floor(width)),
+                height: Math.max(1, Math.floor(height)),
+            };
+        };
+
+        const initialSize = getMountSize();
 
         const scene = new THREE.Scene();
         scene.background = new THREE.Color(0x000000);
         scene.fog = new THREE.FogExp2(0x000000, 0.0008); // Reduced density for better visibility
 
-        const camera = new THREE.PerspectiveCamera(55, width / height, 0.1, 4000);
+        const camera = new THREE.PerspectiveCamera(55, initialSize.width / initialSize.height, 0.1, 4000);
         const renderer = new THREE.WebGLRenderer({ antialias: true, alpha: true });
-        renderer.setSize(width, height);
+        renderer.setSize(initialSize.width, initialSize.height);
         renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
-        mountRef.current.appendChild(renderer.domElement);
+        mountElement.appendChild(renderer.domElement);
         canvasRef.current = renderer.domElement;
 
         // --- Cinematic Lighting Orchestration ---
@@ -182,14 +197,12 @@ export const ForbiddingBlocks: React.FC = () => {
         camera.lookAt(0, 0, 0);
 
         const resizeObserver = new ResizeObserver(() => {
-            if (!mountRef.current) return;
-            const w = mountRef.current.clientWidth;
-            const h = mountRef.current.clientHeight;
-            camera.aspect = w / h;
+            const { width, height } = getMountSize();
+            camera.aspect = width / height;
             camera.updateProjectionMatrix();
-            renderer.setSize(w, h);
+            renderer.setSize(width, height);
         });
-        if (mountRef.current) resizeObserver.observe(mountRef.current);
+        resizeObserver.observe(mountElement);
 
         let time = 0;
         let animationId: number;
@@ -262,12 +275,12 @@ export const ForbiddingBlocks: React.FC = () => {
             // Clear scene
             scene.clear();
 
-            if (mountRef.current && renderer.domElement) {
-                mountRef.current.removeChild(renderer.domElement);
+            if (mountElement && renderer.domElement && mountElement.contains(renderer.domElement)) {
+                mountElement.removeChild(renderer.domElement);
             }
             renderer.dispose();
         };
-    }, []);
+    }, [exportSettings.isExportMode]);
 
     useEffect(() => {
         return () => {
@@ -279,23 +292,27 @@ export const ForbiddingBlocks: React.FC = () => {
     }, []);
 
     return (
-        <div className="forbidding-container">
-            <div ref={mountRef} className="blocks-canvas" />
-            <div className="grain-overlay" />
+        <ExportFrame aspect={exportSettings.aspect} active={exportSettings.isExportMode}>
+            <div className="forbidding-container">
+                <div ref={mountRef} className="blocks-canvas" />
+                <div className="grain-overlay" />
 
-            {/* Record Button - Dev only */}
-            {process.env.NODE_ENV !== 'production' && (
-                <button
-                    className={`record-button ${isRecording ? 'recording' : ''}`}
-                    onClick={toggleRecording}
-                    title={isRecording ? 'Stop Recording' : 'Start Recording'}
-                >
-                    <span className="record-icon" />
-                    {isRecording && <span className="record-time">{formatTime(recordingTime)}</span>}
-                </button>
-            )}
+                {/* Record Button - Dev only */}
+                {process.env.NODE_ENV !== 'production' && !exportSettings.isExportMode && (
+                    <button
+                        className={`record-button ${isRecording ? 'recording' : ''}`}
+                        onClick={toggleRecording}
+                        title={isRecording ? 'Stop Recording' : 'Start Recording'}
+                    >
+                        <span className="record-icon" />
+                        {isRecording && <span className="record-time">{formatTime(recordingTime)}</span>}
+                    </button>
+                )}
 
-            <div className="art-piece-watermark">FORBIDDING_BLOCKS // V_01</div>
-        </div>
+                {!exportSettings.isExportMode && (
+                    <div className="art-piece-watermark">FORBIDDING_BLOCKS // V_01</div>
+                )}
+            </div>
+        </ExportFrame>
     );
 };

--- a/src/components/Forest/Forest.tsx
+++ b/src/components/Forest/Forest.tsx
@@ -8,9 +8,13 @@ import './Forest.css';
 import { createInstancedForest } from './InstancedForest';
 import { createFireflies, updateFireflies } from './Fireflies';
 import { ActiveTreeOverlay } from './ActiveTreeOverlay';
+import { ExportFrame } from '../ExportFrame/ExportFrame';
+import { forestVisualExport } from '../../data/transmissions';
+import { useExportSettings } from '../../lib/exportSettings';
 
 const Forest: React.FC = () => {
     const containerRef = useRef<HTMLDivElement>(null);
+    const exportSettings = useExportSettings(forestVisualExport);
     const sceneRef = useRef<THREE.Scene | null>(null);
 
     const [isRecording, setIsRecording] = React.useState(false);
@@ -90,6 +94,20 @@ const Forest: React.FC = () => {
 
     useEffect(() => {
         if (!containerRef.current) return;
+        const mountElement = containerRef.current;
+
+        const getMountSize = () => {
+            const rect = mountElement.getBoundingClientRect();
+            const width = rect.width || mountElement.clientWidth || window.innerWidth;
+            const height = rect.height || mountElement.clientHeight || window.innerHeight;
+
+            return {
+                width: Math.max(1, Math.floor(width)),
+                height: Math.max(1, Math.floor(height)),
+            };
+        };
+
+        const initialSize = getMountSize();
 
         // SCENE SETUP
         const scene = new THREE.Scene();
@@ -97,13 +115,18 @@ const Forest: React.FC = () => {
         scene.background = new THREE.Color(0x000205); // Very deep blue-black
         scene.fog = new THREE.FogExp2(0x000205, 0.035); // Slightly thicker fog
 
-        const camera = new THREE.PerspectiveCamera(75, window.innerWidth / window.innerHeight, 0.1, 1000);
+        const camera = new THREE.PerspectiveCamera(
+            75,
+            initialSize.width / initialSize.height,
+            0.1,
+            1000
+        );
         camera.position.set(0, 10, 40); // Pull back slightly for more awe
 
         const renderer = new THREE.WebGLRenderer({ antialias: true, alpha: true });
-        renderer.setSize(window.innerWidth, window.innerHeight);
+        renderer.setSize(initialSize.width, initialSize.height);
         renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
-        containerRef.current.appendChild(renderer.domElement);
+        mountElement.appendChild(renderer.domElement);
         canvasRef.current = renderer.domElement; // Set canvas ref
 
         // INSTANCED FOREST
@@ -138,7 +161,7 @@ const Forest: React.FC = () => {
 
         // TUNE BLOOM - Lower it significantly
         const bloomPass = new UnrealBloomPass(
-            new THREE.Vector2(window.innerWidth, window.innerHeight),
+            new THREE.Vector2(initialSize.width, initialSize.height),
             0.6, 0.4, 0.85
         );
         composer.addPass(bloomPass);
@@ -203,17 +226,21 @@ const Forest: React.FC = () => {
 
         animate();
 
-        const handleResize = () => {
-            camera.aspect = window.innerWidth / window.innerHeight;
+        const resizeToMount = () => {
+            const { width, height } = getMountSize();
+            camera.aspect = width / height;
             camera.updateProjectionMatrix();
-            renderer.setSize(window.innerWidth, window.innerHeight);
-            composer.setSize(window.innerWidth, window.innerHeight);
+            renderer.setSize(width, height);
+            composer.setSize(width, height);
         };
-        window.addEventListener('resize', handleResize);
+        resizeToMount();
+
+        const resizeObserver = new ResizeObserver(resizeToMount);
+        resizeObserver.observe(mountElement);
 
         return () => {
             cancelAnimationFrame(animationId);
-            window.removeEventListener('resize', handleResize);
+            resizeObserver.disconnect();
 
             // Dispose scene objects
             scene.traverse((obj) => {
@@ -239,8 +266,8 @@ const Forest: React.FC = () => {
             composer.dispose();
             renderer.dispose();
 
-            if (containerRef.current?.contains(renderer.domElement)) {
-                containerRef.current.removeChild(renderer.domElement);
+            if (mountElement.contains(renderer.domElement)) {
+                mountElement.removeChild(renderer.domElement);
             }
             if (recordingIntervalRef.current) {
                 clearInterval(recordingIntervalRef.current);
@@ -249,22 +276,24 @@ const Forest: React.FC = () => {
                 mediaRecorderRef.current.stop();
             }
         };
-    }, []);
+    }, [exportSettings.isExportMode]);
 
     return (
-        <div ref={containerRef} style={{ width: '100%', height: '100vh', background: 'black', overflow: 'hidden' }}>
-            {/* Record Button - Dev only */}
-            {process.env.NODE_ENV !== 'production' && (
-                <button
-                    className={`record-button ${isRecording ? 'recording' : ''}`}
-                    onClick={toggleRecording}
-                    title={isRecording ? 'Stop Recording' : 'Start Recording'}
-                >
-                    <span className="record-icon" />
-                    {isRecording && <span className="record-time">{formatTime(recordingTime)}</span>}
-                </button>
-            )}
-        </div>
+        <ExportFrame aspect={exportSettings.aspect} active={exportSettings.isExportMode}>
+            <div ref={containerRef} style={{ width: '100%', height: '100%', background: 'black', overflow: 'hidden' }}>
+                {/* Record Button - Dev only */}
+                {process.env.NODE_ENV !== 'production' && !exportSettings.isExportMode && (
+                    <button
+                        className={`record-button ${isRecording ? 'recording' : ''}`}
+                        onClick={toggleRecording}
+                        title={isRecording ? 'Stop Recording' : 'Start Recording'}
+                    >
+                        <span className="record-icon" />
+                        {isRecording && <span className="record-time">{formatTime(recordingTime)}</span>}
+                    </button>
+                )}
+            </div>
+        </ExportFrame>
     );
 };
 

--- a/src/components/Growth/Growth.css
+++ b/src/components/Growth/Growth.css
@@ -15,6 +15,8 @@
     position: absolute;
     top: 0;
     left: 0;
+    width: 100%;
+    height: 100%;
     z-index: 1;
     display: block;
 }
@@ -77,8 +79,9 @@
 }
 
 .growth-container {
-    width: 100vw;
-    height: 100vh;
+    position: relative;
+    width: 100%;
+    height: 100%;
     overflow: hidden;
     font-family: 'IBM Plex Mono', monospace;
     font-size: 9px;

--- a/src/components/Growth/Growth.tsx
+++ b/src/components/Growth/Growth.tsx
@@ -1,5 +1,8 @@
 import React, { useEffect, useRef, useState } from 'react';
 import * as THREE from 'three';
+import { ExportFrame } from '../ExportFrame/ExportFrame';
+import { growthVisualExport } from '../../data/transmissions';
+import { useExportSettings } from '../../lib/exportSettings';
 import './Growth.css';
 
 const LOG_MESSAGES = [
@@ -18,6 +21,7 @@ const LOG_MESSAGES = [
 
 export const Growth: React.FC = () => {
     const mountRef = useRef<HTMLDivElement>(null);
+    const exportSettings = useExportSettings(growthVisualExport);
     const [logs, setLogs] = useState<string[]>([]);
     const logContainerRef = useRef<HTMLDivElement>(null);
     const [showText, setShowText] = useState(false);
@@ -100,17 +104,29 @@ export const Growth: React.FC = () => {
     // Neural Network / Tree Simulation Logic
     useEffect(() => {
         if (!mountRef.current) return;
+        const mountElement = mountRef.current;
 
-        const width = window.innerWidth;
-        const height = window.innerHeight;
+        const getMountSize = () => {
+            const rect = mountElement.getBoundingClientRect();
+            const width = rect.width || mountElement.clientWidth || window.innerWidth;
+            const height = rect.height || mountElement.clientHeight || window.innerHeight;
+
+            return {
+                width: Math.max(1, Math.floor(width)),
+                height: Math.max(1, Math.floor(height)),
+            };
+        };
+
+        const initialSize = getMountSize();
+        let mountWidth = initialSize.width;
 
         // Scene setup
         const scene = new THREE.Scene();
-        const camera = new THREE.PerspectiveCamera(75, width / height, 0.1, 1000);
+        const camera = new THREE.PerspectiveCamera(75, initialSize.width / initialSize.height, 0.1, 1000);
         const renderer = new THREE.WebGLRenderer({ antialias: true, alpha: true });
-        renderer.setSize(width, height);
+        renderer.setSize(initialSize.width, initialSize.height);
         renderer.setPixelRatio(window.devicePixelRatio);
-        mountRef.current.appendChild(renderer.domElement);
+        mountElement.appendChild(renderer.domElement);
         canvasRef.current = renderer.domElement;
 
         // Disposal Helper
@@ -230,13 +246,14 @@ export const Growth: React.FC = () => {
         const resizeObserver = new ResizeObserver((entries) => {
             for (let entry of entries) {
                 const { width, height } = entry.contentRect;
+                mountWidth = width;
                 camera.aspect = width / height;
                 camera.updateProjectionMatrix();
                 renderer.setSize(width, height);
             }
         });
 
-        if (mountRef.current) resizeObserver.observe(mountRef.current);
+        resizeObserver.observe(mountElement);
 
         // Animation
         let animationId: number;
@@ -251,7 +268,7 @@ export const Growth: React.FC = () => {
             treeMesh.rotation.x = Math.cos(time * 0.3) * swayAmount;
             nodes.rotation.x = Math.cos(time * 0.3) * swayAmount;
 
-            const isMobile = window.innerWidth < 768;
+            const isMobile = mountWidth < 768;
             camera.position.x = Math.sin(time * 0.1) * 60;
             camera.position.y = 10 + Math.cos(time * 0.05) * 10;
             camera.position.z = isMobile ? 140 : 110;
@@ -280,12 +297,12 @@ export const Growth: React.FC = () => {
 
             scene.clear();
 
-            if (mountRef.current && renderer.domElement) {
-                mountRef.current.removeChild(renderer.domElement);
+            if (mountElement && renderer.domElement && mountElement.contains(renderer.domElement)) {
+                mountElement.removeChild(renderer.domElement);
             }
             renderer.dispose();
         };
-    }, []);
+    }, [exportSettings.isExportMode]);
 
     // Algorithm Learning Logs simulation
     useEffect(() => {
@@ -322,33 +339,42 @@ export const Growth: React.FC = () => {
     }, []);
 
     return (
-        <div className="growth-container" onClick={() => setShowText(prev => !prev)}>
-            <div ref={mountRef} className="nn-canvas" />
+        <ExportFrame aspect={exportSettings.aspect} active={exportSettings.isExportMode}>
+            <div
+                className="growth-container"
+                onClick={() => {
+                    if (!exportSettings.isExportMode) {
+                        setShowText(prev => !prev);
+                    }
+                }}
+            >
+                <div ref={mountRef} className="nn-canvas" />
 
-            {/* Record Button - Dev only */}
-            {process.env.NODE_ENV !== 'production' && (
-                <button
-                    className={`record-button ${isRecording ? 'recording' : ''}`}
-                    onClick={toggleRecording}
-                    title={isRecording ? 'Stop Recording' : 'Start Recording'}
-                >
-                    <span className="record-icon" />
-                    {isRecording && <span className="record-time">{formatTime(recordingTime)}</span>}
-                </button>
-            )}
+                {/* Record Button - Dev only */}
+                {process.env.NODE_ENV !== 'production' && !exportSettings.isExportMode && (
+                    <button
+                        className={`record-button ${isRecording ? 'recording' : ''}`}
+                        onClick={toggleRecording}
+                        title={isRecording ? 'Stop Recording' : 'Start Recording'}
+                    >
+                        <span className="record-icon" />
+                        {isRecording && <span className="record-time">{formatTime(recordingTime)}</span>}
+                    </button>
+                )}
 
-            {showText && (
-                <div className="test-hud">
-                    {/* Bottom-Right Logs */}
-                    <div className="test-hud-bottom">
-                        <div className="learning-logs" ref={logContainerRef}>
-                            {logs.map((log, i) => (
-                                <div key={i} className="log-entry">{log}</div>
-                            ))}
+                {showText && !exportSettings.isExportMode && (
+                    <div className="test-hud">
+                        {/* Bottom-Right Logs */}
+                        <div className="test-hud-bottom">
+                            <div className="learning-logs" ref={logContainerRef}>
+                                {logs.map((log, i) => (
+                                    <div key={i} className="log-entry">{log}</div>
+                                ))}
+                            </div>
                         </div>
                     </div>
-                </div>
-            )}
-        </div>
+                )}
+            </div>
+        </ExportFrame>
     );
 };

--- a/src/components/Hand/Hand.tsx
+++ b/src/components/Hand/Hand.tsx
@@ -5,10 +5,14 @@ import { EffectComposer } from 'three/examples/jsm/postprocessing/EffectComposer
 import { RenderPass } from 'three/examples/jsm/postprocessing/RenderPass';
 import { UnrealBloomPass } from 'three/examples/jsm/postprocessing/UnrealBloomPass';
 import { ShaderPass } from 'three/examples/jsm/postprocessing/ShaderPass';
+import { ExportFrame } from '../ExportFrame/ExportFrame';
+import { handVisualExport } from '../../data/transmissions';
+import { useExportSettings } from '../../lib/exportSettings';
 import './Hand.css';
 
 export const Hand: React.FC = () => {
     const mountRef = useRef<HTMLDivElement>(null);
+    const exportSettings = useExportSettings(handVisualExport);
     const [isRecording, setIsRecording] = useState(false);
     const [recordingTime, setRecordingTime] = useState(0);
     const mediaRecorderRef = useRef<MediaRecorder | null>(null);
@@ -60,6 +64,21 @@ export const Hand: React.FC = () => {
 
     useEffect(() => {
         if (!mountRef.current) return;
+        const mountElement = mountRef.current;
+
+        const getMountSize = () => {
+            const rect = mountElement.getBoundingClientRect();
+            const width = rect.width || mountElement.clientWidth || window.innerWidth;
+            const height = rect.height || mountElement.clientHeight || window.innerHeight;
+
+            return {
+                width: Math.max(1, Math.floor(width)),
+                height: Math.max(1, Math.floor(height)),
+            };
+        };
+
+        const initialSize = getMountSize();
+        let mountAspect = initialSize.width / initialSize.height;
 
         let abortController = new AbortController();
         let loadedGltf: any = null;
@@ -68,15 +87,15 @@ export const Hand: React.FC = () => {
         const scene = new THREE.Scene();
         scene.fog = new THREE.FogExp2(0x000000, 0.035);
 
-        const camera = new THREE.PerspectiveCamera(50, window.innerWidth / window.innerHeight, 0.1, 1000);
-        camera.position.z = 6;
+        const camera = new THREE.PerspectiveCamera(50, mountAspect, 0.1, 1000);
+        camera.position.z = mountAspect < 0.8 ? 8 : 6;
 
         const renderer = new THREE.WebGLRenderer({ antialias: true, alpha: true });
-        renderer.setSize(window.innerWidth, window.innerHeight);
+        renderer.setSize(initialSize.width, initialSize.height);
         renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
         renderer.toneMapping = THREE.ReinhardToneMapping;
         renderer.toneMappingExposure = 1.0;
-        mountRef.current.appendChild(renderer.domElement);
+        mountElement.appendChild(renderer.domElement);
         canvasRef.current = renderer.domElement;
 
         // Post-processing
@@ -84,7 +103,7 @@ export const Hand: React.FC = () => {
         composer.addPass(new RenderPass(scene, camera));
 
         const bloomPass = new UnrealBloomPass(
-            new THREE.Vector2(window.innerWidth, window.innerHeight),
+            new THREE.Vector2(initialSize.width, initialSize.height),
             0.8,   // strength - subtle glow, preserves form
             0.5,   // radius - tighter spread
             0.4    // threshold - only bright elements bloom
@@ -133,6 +152,17 @@ export const Hand: React.FC = () => {
         });
         composer.addPass(grainPass);
 
+        const resizeToMount = () => {
+            const { width, height } = getMountSize();
+            mountAspect = width / height;
+            camera.aspect = mountAspect;
+            camera.position.z = mountAspect < 0.8 ? 8 : 6;
+            camera.updateProjectionMatrix();
+            renderer.setSize(width, height);
+            composer.setSize(width, height);
+            bloomPass.resolution.set(width, height);
+        };
+
         const handleContextLost = (event: Event) => {
             event.preventDefault();
             console.warn('WebGL context lost');
@@ -141,8 +171,7 @@ export const Hand: React.FC = () => {
 
         const handleContextRestored = () => {
             console.log('WebGL context restored');
-            renderer.setSize(window.innerWidth, window.innerHeight);
-            composer.setSize(window.innerWidth, window.innerHeight);
+            resizeToMount();
             if (!animationId && isComponentMounted) animate();
         };
 
@@ -467,20 +496,16 @@ export const Hand: React.FC = () => {
             composer.render();
         };
 
-        const handleResize = () => {
-            camera.aspect = window.innerWidth / window.innerHeight;
-            camera.updateProjectionMatrix();
-            renderer.setSize(window.innerWidth, window.innerHeight);
-            composer.setSize(window.innerWidth, window.innerHeight);
-            bloomPass.resolution.set(window.innerWidth, window.innerHeight);
-        };
-        window.addEventListener('resize', handleResize);
+        resizeToMount();
+
+        const resizeObserver = new ResizeObserver(resizeToMount);
+        resizeObserver.observe(mountElement);
 
         return () => {
             isComponentMounted = false;
             abortController.abort();
             if (animationId) cancelAnimationFrame(animationId);
-            window.removeEventListener('resize', handleResize);
+            resizeObserver.disconnect();
 
             // Dispose post-processing
             composer.dispose();
@@ -499,29 +524,31 @@ export const Hand: React.FC = () => {
 
             renderer.dispose();
             if (loadedGltf) { /* dispose traversal */ }
-            if (mountRef.current && renderer.domElement) {
-                if (mountRef.current.contains(renderer.domElement)) {
-                    mountRef.current.removeChild(renderer.domElement);
+            if (mountElement && renderer.domElement) {
+                if (mountElement.contains(renderer.domElement)) {
+                    mountElement.removeChild(renderer.domElement);
                 }
             }
         };
-    }, []);
+    }, [exportSettings.isExportMode]);
 
     return (
-        <div className="hand-container">
-            <div ref={mountRef} className="hand-canvas" />
-            {process.env.NODE_ENV !== 'production' && (
-                <button
-                    className={`record-button ${isRecording ? 'recording' : ''}`}
-                    onClick={toggleRecording}
-                    title={isRecording ? 'Stop Recording' : 'Start Recording'}
-                >
-                    <span className="record-icon" />
-                    {isRecording && <span className="record-time">
-                        {Math.floor(recordingTime / 60)}:{(recordingTime % 60).toString().padStart(2, '0')}
-                    </span>}
-                </button>
-            )}
-        </div>
+        <ExportFrame aspect={exportSettings.aspect} active={exportSettings.isExportMode}>
+            <div className="hand-container">
+                <div ref={mountRef} className="hand-canvas" />
+                {process.env.NODE_ENV !== 'production' && !exportSettings.isExportMode && (
+                    <button
+                        className={`record-button ${isRecording ? 'recording' : ''}`}
+                        onClick={toggleRecording}
+                        title={isRecording ? 'Stop Recording' : 'Start Recording'}
+                    >
+                        <span className="record-icon" />
+                        {isRecording && <span className="record-time">
+                            {Math.floor(recordingTime / 60)}:{(recordingTime % 60).toString().padStart(2, '0')}
+                        </span>}
+                    </button>
+                )}
+            </div>
+        </ExportFrame>
     );
 };

--- a/src/components/Learning/Learning.css
+++ b/src/components/Learning/Learning.css
@@ -1,7 +1,7 @@
 .learning-container {
   position: relative;
-  width: 100vw;
-  height: 100vh;
+  width: 100%;
+  height: 100%;
   background: #000;
   overflow: hidden;
   font-family: 'IBM Plex Mono', monospace;

--- a/src/components/Learning/Learning.tsx
+++ b/src/components/Learning/Learning.tsx
@@ -1,5 +1,8 @@
 import React, { useEffect, useRef, useState } from 'react';
 import * as THREE from 'three';
+import { ExportFrame } from '../ExportFrame/ExportFrame';
+import { learningVisualExport } from '../../data/transmissions';
+import { useExportSettings } from '../../lib/exportSettings';
 import './Learning.css';
 
 // Q-Learning Grid World Configuration
@@ -34,6 +37,7 @@ interface TrainingMetrics {
 
 export const Learning: React.FC = () => {
   const mountRef = useRef<HTMLDivElement>(null);
+  const exportSettings = useExportSettings(learningVisualExport);
   const [metrics, setMetrics] = useState<TrainingMetrics>({
     epoch: 0,
     loss: 1.0,
@@ -240,16 +244,27 @@ export const Learning: React.FC = () => {
   // Three.js Loss Landscape Visualization
   useEffect(() => {
     if (!mountRef.current) return;
+    const mountElement = mountRef.current;
 
-    const width = window.innerWidth;
-    const height = window.innerHeight;
+    const getMountSize = () => {
+      const rect = mountElement.getBoundingClientRect();
+      const width = rect.width || mountElement.clientWidth || window.innerWidth;
+      const height = rect.height || mountElement.clientHeight || window.innerHeight;
+
+      return {
+        width: Math.max(1, Math.floor(width)),
+        height: Math.max(1, Math.floor(height)),
+      };
+    };
+
+    const initialSize = getMountSize();
 
     const scene = new THREE.Scene();
-    const camera = new THREE.PerspectiveCamera(60, width / height, 0.1, 1000);
+    const camera = new THREE.PerspectiveCamera(60, initialSize.width / initialSize.height, 0.1, 1000);
     const renderer = new THREE.WebGLRenderer({ antialias: true, alpha: true });
-    renderer.setSize(width, height);
+    renderer.setSize(initialSize.width, initialSize.height);
     renderer.setPixelRatio(window.devicePixelRatio);
-    mountRef.current.appendChild(renderer.domElement);
+    mountElement.appendChild(renderer.domElement);
     canvasRef.current = renderer.domElement;
 
     // Loss landscape function - multiple local minima
@@ -389,17 +404,19 @@ export const Learning: React.FC = () => {
     animate();
 
     // Resize handler
-    const handleResize = () => {
-      const w = window.innerWidth;
-      const h = window.innerHeight;
-      camera.aspect = w / h;
+    const resizeToMount = () => {
+      const { width, height } = getMountSize();
+      camera.aspect = width / height;
       camera.updateProjectionMatrix();
-      renderer.setSize(w, h);
+      renderer.setSize(width, height);
     };
-    window.addEventListener('resize', handleResize);
+    resizeToMount();
+
+    const resizeObserver = new ResizeObserver(resizeToMount);
+    resizeObserver.observe(mountElement);
 
     return () => {
-      window.removeEventListener('resize', handleResize);
+      resizeObserver.disconnect();
       cancelAnimationFrame(animationId);
 
       // Dispose of all geometries and materials to prevent GPU memory leaks
@@ -419,12 +436,12 @@ export const Learning: React.FC = () => {
       // Clean up scene
       scene.clear();
 
-      if (mountRef.current && renderer.domElement) {
-        mountRef.current.removeChild(renderer.domElement);
+      if (mountElement && renderer.domElement && mountElement.contains(renderer.domElement)) {
+        mountElement.removeChild(renderer.domElement);
       }
       renderer.dispose();
     };
-  }, []);
+  }, [exportSettings.isExportMode]);
 
   // Get best action for a cell
   const getBestAction = (x: number, y: number): number => {
@@ -458,20 +475,21 @@ export const Learning: React.FC = () => {
   }, []);
 
   return (
-    <div className="learning-container">
-      <div ref={mountRef} className="learning-canvas-container" />
+    <ExportFrame aspect={exportSettings.aspect} active={exportSettings.isExportMode}>
+      <div className="learning-container">
+        <div ref={mountRef} className="learning-canvas-container" />
 
-      {/* Record Button - Dev only */}
-      {process.env.NODE_ENV !== 'production' && (
-        <button
-          className={`record-button ${isRecording ? 'recording' : ''}`}
-          onClick={toggleRecording}
-          title={isRecording ? 'Stop Recording' : 'Start Recording'}
-        >
-          <span className="record-icon" />
-          {isRecording && <span className="record-time">{formatTime(recordingTime)}</span>}
-        </button>
-      )}
+        {/* Record Button - Dev only */}
+        {process.env.NODE_ENV !== 'production' && !exportSettings.isExportMode && (
+          <button
+            className={`record-button ${isRecording ? 'recording' : ''}`}
+            onClick={toggleRecording}
+            title={isRecording ? 'Stop Recording' : 'Start Recording'}
+          >
+            <span className="record-icon" />
+            {isRecording && <span className="record-time">{formatTime(recordingTime)}</span>}
+          </button>
+        )}
 
       {/* Training Metrics - Bottom Left (Commented Out per Request) */}
       {/* 
@@ -504,38 +522,41 @@ export const Learning: React.FC = () => {
       */}
 
       {/* Signal Matrix - Bottom Right */}
-      <div className="learning-grid-container">
-        {/* <div className="matrix-title">SIGNAL MATRIX // Q-POLICY</div> */}
-        <div
-          className="q-matrix"
-          style={{ gridTemplateColumns: `repeat(${GRID_SIZE}, 1fr)` }}
-        >
-          {Array.from({ length: GRID_SIZE * GRID_SIZE }).map((_, idx) => {
-            const x = idx % GRID_SIZE;
-            const y = Math.floor(idx / GRID_SIZE);
-            const isAgent = agentPos.x === x && agentPos.y === y;
-            const isGoal = GOAL_POS.x === x && GOAL_POS.y === y;
-            const isObstacle = OBSTACLES.some(o => o.x === x && o.y === y);
-            const bestAction = getBestAction(x, y);
-            const intensity = getQIntensity(x, y);
+        {!exportSettings.isExportMode && (
+          <div className="learning-grid-container">
+            {/* <div className="matrix-title">SIGNAL MATRIX // Q-POLICY</div> */}
+            <div
+              className="q-matrix"
+              style={{ gridTemplateColumns: `repeat(${GRID_SIZE}, 1fr)` }}
+            >
+              {Array.from({ length: GRID_SIZE * GRID_SIZE }).map((_, idx) => {
+                const x = idx % GRID_SIZE;
+                const y = Math.floor(idx / GRID_SIZE);
+                const isAgent = agentPos.x === x && agentPos.y === y;
+                const isGoal = GOAL_POS.x === x && GOAL_POS.y === y;
+                const isObstacle = OBSTACLES.some(o => o.x === x && o.y === y);
+                const bestAction = getBestAction(x, y);
+                const intensity = getQIntensity(x, y);
 
-            return (
-              <div
-                key={idx}
-                className={`matrix-cell ${isAgent ? 'agent' : ''} ${isGoal ? 'goal' : ''} ${isObstacle ? 'obstacle' : ''}`}
-                style={{
-                  backgroundColor: isObstacle
-                    ? undefined
-                    : `rgba(255, 255, 255, ${intensity * 0.1})`,
-                }}
-              >
-                {isGoal ? <div className="goal-beacon"></div> : isObstacle ? '\u2716' : isAgent ? <div className="agent-beacon"></div> :
-                  bestAction >= 0 ? <span className="matrix-spark">{ACTION_ARROWS[bestAction]}</span> : ''}
-              </div>
-            );
-          })}
-        </div>
+                return (
+                  <div
+                    key={idx}
+                    className={`matrix-cell ${isAgent ? 'agent' : ''} ${isGoal ? 'goal' : ''} ${isObstacle ? 'obstacle' : ''}`}
+                    style={{
+                      backgroundColor: isObstacle
+                        ? undefined
+                        : `rgba(255, 255, 255, ${intensity * 0.1})`,
+                    }}
+                  >
+                    {isGoal ? <div className="goal-beacon"></div> : isObstacle ? '\u2716' : isAgent ? <div className="agent-beacon"></div> :
+                      bestAction >= 0 ? <span className="matrix-spark">{ACTION_ARROWS[bestAction]}</span> : ''}
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+        )}
       </div>
-    </div>
+    </ExportFrame>
   );
 };

--- a/src/components/Murmur/Murmur.tsx
+++ b/src/components/Murmur/Murmur.tsx
@@ -4,6 +4,9 @@ import { EffectComposer } from 'three/examples/jsm/postprocessing/EffectComposer
 import { RenderPass } from 'three/examples/jsm/postprocessing/RenderPass';
 import { UnrealBloomPass } from 'three/examples/jsm/postprocessing/UnrealBloomPass';
 import { ShaderPass } from 'three/examples/jsm/postprocessing/ShaderPass';
+import { ExportFrame } from '../ExportFrame/ExportFrame';
+import { murmurVisualExport } from '../../data/transmissions';
+import { useExportSettings } from '../../lib/exportSettings';
 import './Murmur.css';
 
 const BOID_COUNT = 8000;
@@ -22,7 +25,7 @@ class SpatialHash {
     private activeCells: number[];
     private activeCount: number;
     // Pre-allocated query result buffer
-    private queryBuf: number[];
+    public queryBuf: number[];
     public queryLen: number;
 
     constructor(cellSize: number) {
@@ -179,6 +182,7 @@ function getScatterBurst(phase: number): number {
 
 export const Murmur: React.FC = () => {
     const mountRef = useRef<HTMLDivElement>(null);
+    const exportSettings = useExportSettings(murmurVisualExport);
     const [isRecording, setIsRecording] = useState(false);
     const [recordingTime, setRecordingTime] = useState(0);
     const mediaRecorderRef = useRef<MediaRecorder | null>(null);
@@ -230,6 +234,21 @@ export const Murmur: React.FC = () => {
 
     useEffect(() => {
         if (!mountRef.current) return;
+        const mountElement = mountRef.current;
+
+        const getMountSize = () => {
+            const rect = mountElement.getBoundingClientRect();
+            const width = rect.width || mountElement.clientWidth || window.innerWidth;
+            const height = rect.height || mountElement.clientHeight || window.innerHeight;
+
+            return {
+                width: Math.max(1, Math.floor(width)),
+                height: Math.max(1, Math.floor(height)),
+            };
+        };
+
+        const initialSize = getMountSize();
+        let mountAspect = initialSize.width / initialSize.height;
 
         let isComponentMounted = true;
 
@@ -237,15 +256,15 @@ export const Murmur: React.FC = () => {
         const scene = new THREE.Scene();
         scene.fog = new THREE.FogExp2(0x000000, 0.04);
 
-        const camera = new THREE.PerspectiveCamera(50, window.innerWidth / window.innerHeight, 0.1, 1000);
-        camera.position.z = 7;
+        const camera = new THREE.PerspectiveCamera(50, mountAspect, 0.1, 1000);
+        camera.position.z = mountAspect < 0.8 ? 9 : 7;
 
         const renderer = new THREE.WebGLRenderer({ antialias: true, alpha: true });
-        renderer.setSize(window.innerWidth, window.innerHeight);
+        renderer.setSize(initialSize.width, initialSize.height);
         renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
         renderer.toneMapping = THREE.ReinhardToneMapping;
         renderer.toneMappingExposure = 1.0;
-        mountRef.current.appendChild(renderer.domElement);
+        mountElement.appendChild(renderer.domElement);
         canvasRef.current = renderer.domElement;
 
         // Post-processing
@@ -253,7 +272,7 @@ export const Murmur: React.FC = () => {
         composer.addPass(new RenderPass(scene, camera));
 
         const bloomPass = new UnrealBloomPass(
-            new THREE.Vector2(window.innerWidth, window.innerHeight),
+            new THREE.Vector2(initialSize.width, initialSize.height),
             1.0, 0.6, 0.3
         );
         composer.addPass(bloomPass);
@@ -298,8 +317,7 @@ export const Murmur: React.FC = () => {
             if (animationId) cancelAnimationFrame(animationId);
         };
         const handleContextRestored = () => {
-            renderer.setSize(window.innerWidth, window.innerHeight);
-            composer.setSize(window.innerWidth, window.innerHeight);
+            resizeToMount();
             if (!animationId && isComponentMounted) animate();
         };
         renderer.domElement.addEventListener('webglcontextlost', handleContextLost);
@@ -532,7 +550,8 @@ export const Murmur: React.FC = () => {
             // Camera - mostly head-on to flat logo, gentle sway
             camera.position.x = Math.sin(time * 0.04) * 0.6;
             camera.position.y = Math.cos(time * 0.03) * 0.4;
-            camera.position.z = 7 + Math.sin(time * 0.02) * 0.3;
+            const cameraBaseZ = mountAspect < 0.8 ? 9 : 7;
+            camera.position.z = cameraBaseZ + Math.sin(time * 0.02) * 0.3;
             camera.lookAt(0, 0, 0);
 
             // Update grain
@@ -543,19 +562,24 @@ export const Murmur: React.FC = () => {
 
         animate();
 
-        const handleResize = () => {
-            camera.aspect = window.innerWidth / window.innerHeight;
+        const resizeToMount = () => {
+            const { width, height } = getMountSize();
+            mountAspect = width / height;
+            camera.aspect = mountAspect;
             camera.updateProjectionMatrix();
-            renderer.setSize(window.innerWidth, window.innerHeight);
-            composer.setSize(window.innerWidth, window.innerHeight);
-            bloomPass.resolution.set(window.innerWidth, window.innerHeight);
+            renderer.setSize(width, height);
+            composer.setSize(width, height);
+            bloomPass.resolution.set(width, height);
         };
-        window.addEventListener('resize', handleResize);
+        resizeToMount();
+
+        const resizeObserver = new ResizeObserver(resizeToMount);
+        resizeObserver.observe(mountElement);
 
         return () => {
             isComponentMounted = false;
             if (animationId) cancelAnimationFrame(animationId);
-            window.removeEventListener('resize', handleResize);
+            resizeObserver.disconnect();
             renderer.domElement.removeEventListener('webglcontextlost', handleContextLost);
             renderer.domElement.removeEventListener('webglcontextrestored', handleContextRestored);
             composer.dispose();
@@ -563,27 +587,29 @@ export const Murmur: React.FC = () => {
             mat.dispose();
             sprite.dispose();
             renderer.dispose();
-            if (mountRef.current && renderer.domElement && mountRef.current.contains(renderer.domElement)) {
-                mountRef.current.removeChild(renderer.domElement);
+            if (mountElement && renderer.domElement && mountElement.contains(renderer.domElement)) {
+                mountElement.removeChild(renderer.domElement);
             }
         };
-    }, []);
+    }, [exportSettings.isExportMode]);
 
     return (
-        <div className="murmur-container">
-            <div ref={mountRef} className="murmur-canvas" />
-            {process.env.NODE_ENV !== 'production' && (
-                <button
-                    className={`record-button ${isRecording ? 'recording' : ''}`}
-                    onClick={toggleRecording}
-                    title={isRecording ? 'Stop Recording' : 'Start Recording'}
-                >
-                    <span className="record-icon" />
-                    {isRecording && <span className="record-time">
-                        {Math.floor(recordingTime / 60)}:{(recordingTime % 60).toString().padStart(2, '0')}
-                    </span>}
-                </button>
-            )}
-        </div>
+        <ExportFrame aspect={exportSettings.aspect} active={exportSettings.isExportMode}>
+            <div className="murmur-container">
+                <div ref={mountRef} className="murmur-canvas" />
+                {process.env.NODE_ENV !== 'production' && !exportSettings.isExportMode && (
+                    <button
+                        className={`record-button ${isRecording ? 'recording' : ''}`}
+                        onClick={toggleRecording}
+                        title={isRecording ? 'Stop Recording' : 'Start Recording'}
+                    >
+                        <span className="record-icon" />
+                        {isRecording && <span className="record-time">
+                            {Math.floor(recordingTime / 60)}:{(recordingTime % 60).toString().padStart(2, '0')}
+                        </span>}
+                    </button>
+                )}
+            </div>
+        </ExportFrame>
     );
 };

--- a/src/components/Nerve/Nerve.tsx
+++ b/src/components/Nerve/Nerve.tsx
@@ -1,5 +1,8 @@
 import React, { useEffect, useRef, useState } from 'react';
 import * as THREE from 'three';
+import { ExportFrame } from '../ExportFrame/ExportFrame';
+import { nerveVisualExport } from '../../data/transmissions';
+import { useExportSettings } from '../../lib/exportSettings';
 import './Nerve.css';
 
 interface Node {
@@ -18,6 +21,7 @@ interface Pulse {
 
 export const Nerve: React.FC = () => {
     const mountRef = useRef<HTMLDivElement>(null);
+    const exportSettings = useExportSettings(nerveVisualExport);
     const [isRecording, setIsRecording] = useState(false);
     const [recordingTime, setRecordingTime] = useState(0);
     const mediaRecorderRef = useRef<MediaRecorder | null>(null);
@@ -72,13 +76,28 @@ export const Nerve: React.FC = () => {
 
     useEffect(() => {
         if (!mountRef.current) return;
+        const mountElement = mountRef.current;
+
+        const getMountSize = () => {
+            const rect = mountElement.getBoundingClientRect();
+            const width = rect.width || mountElement.clientWidth || window.innerWidth;
+            const height = rect.height || mountElement.clientHeight || window.innerHeight;
+
+            return {
+                width: Math.max(1, Math.floor(width)),
+                height: Math.max(1, Math.floor(height)),
+            };
+        };
+
+        const initialSize = getMountSize();
+        let mountAspect = initialSize.width / initialSize.height;
 
         const scene = new THREE.Scene();
-        const camera = new THREE.PerspectiveCamera(75, window.innerWidth / window.innerHeight, 0.1, 1000);
+        const camera = new THREE.PerspectiveCamera(75, mountAspect, 0.1, 1000);
         const renderer = new THREE.WebGLRenderer({ antialias: true, alpha: true });
-        renderer.setSize(window.innerWidth, window.innerHeight);
+        renderer.setSize(initialSize.width, initialSize.height);
         renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
-        mountRef.current.appendChild(renderer.domElement);
+        mountElement.appendChild(renderer.domElement);
         canvasRef.current = renderer.domElement;
 
         // --- Geometries and Materials ---
@@ -326,7 +345,8 @@ export const Nerve: React.FC = () => {
                 pulseMaterial.opacity = 0.8 + Math.sin(time * 1.5) * 0.2;
             }
 
-            camera.position.z = 115 + Math.sin(time * 0.4) * 15;
+            const cameraBaseZ = mountAspect < 0.8 ? 155 : 115;
+            camera.position.z = cameraBaseZ + Math.sin(time * 0.4) * 15;
             camera.lookAt(0, 0, 0);
 
             renderer.render(scene, camera);
@@ -334,16 +354,21 @@ export const Nerve: React.FC = () => {
         animate();
 
         // Handle resize
-        const handleResize = () => {
-            camera.aspect = window.innerWidth / window.innerHeight;
+        const resizeToMount = () => {
+            const { width, height } = getMountSize();
+            mountAspect = width / height;
+            camera.aspect = mountAspect;
             camera.updateProjectionMatrix();
-            renderer.setSize(window.innerWidth, window.innerHeight);
+            renderer.setSize(width, height);
         };
-        window.addEventListener('resize', handleResize);
+        resizeToMount();
+
+        const resizeObserver = new ResizeObserver(resizeToMount);
+        resizeObserver.observe(mountElement);
 
         return () => {
             cancelAnimationFrame(animationId);
-            window.removeEventListener('resize', handleResize);
+            resizeObserver.disconnect();
 
             // Clear seizure timeout
             if (seizureTimeoutId) clearTimeout(seizureTimeoutId);
@@ -356,8 +381,8 @@ export const Nerve: React.FC = () => {
                 mediaRecorderRef.current.stop();
             }
 
-            if (mountRef.current && renderer.domElement) {
-                mountRef.current.removeChild(renderer.domElement);
+            if (mountElement && renderer.domElement && mountElement.contains(renderer.domElement)) {
+                mountElement.removeChild(renderer.domElement);
             }
             // Disposal
             lineGeom.dispose();
@@ -371,24 +396,26 @@ export const Nerve: React.FC = () => {
             nodeSprite.dispose();
             renderer.dispose();
         };
-    }, []);
+    }, [exportSettings.isExportMode]);
 
     return (
-        <div className="nerve-container">
-            <div ref={mountRef} className="nerve-canvas" />
+        <ExportFrame aspect={exportSettings.aspect} active={exportSettings.isExportMode}>
+            <div className="nerve-container">
+                <div ref={mountRef} className="nerve-canvas" />
 
-            {/* Record Button */}
-            {process.env.NODE_ENV !== 'production' && (
-                <button
-                    className={`nerve-record-button ${isRecording ? 'recording' : ''}`}
-                    onClick={toggleRecording}
-                >
-                    <span className="nerve-record-icon" />
-                    {isRecording && <span className="nerve-record-time">
-                        {Math.floor(recordingTime / 60)}:{(recordingTime % 60).toString().padStart(2, '0')}
-                    </span>}
-                </button>
-            )}
-        </div>
+                {/* Record Button */}
+                {process.env.NODE_ENV !== 'production' && !exportSettings.isExportMode && (
+                    <button
+                        className={`nerve-record-button ${isRecording ? 'recording' : ''}`}
+                        onClick={toggleRecording}
+                    >
+                        <span className="nerve-record-icon" />
+                        {isRecording && <span className="nerve-record-time">
+                            {Math.floor(recordingTime / 60)}:{(recordingTime % 60).toString().padStart(2, '0')}
+                        </span>}
+                    </button>
+                )}
+            </div>
+        </ExportFrame>
     );
 };

--- a/src/components/Operator/Operator.css
+++ b/src/components/Operator/Operator.css
@@ -1,0 +1,543 @@
+.operator-page {
+  min-height: calc(100dvh - 6rem);
+  color: #f4f4f0;
+  background:
+    linear-gradient(180deg, rgba(0, 0, 0, 0.88), rgba(6, 8, 8, 0.96)),
+    repeating-linear-gradient(90deg, rgba(126, 211, 174, 0.04) 0, rgba(126, 211, 174, 0.04) 1px, transparent 1px, transparent 90px);
+  font-family: 'IBM Plex Mono', monospace;
+}
+
+.operator-shell {
+  width: 100%;
+  max-width: none;
+  margin: 0;
+}
+
+.operator-header,
+.operator-detail-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1.5rem;
+  padding-bottom: 1.5rem;
+  border-bottom: 1px solid rgba(244, 244, 240, 0.16);
+}
+
+.operator-kicker {
+  margin: 0 0 0.55rem;
+  color: #78dcca;
+  font-size: 0.72rem;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+}
+
+.operator-header h1,
+.operator-detail-header h1 {
+  margin: 0;
+  color: #ffffff;
+  font-size: clamp(2rem, 5vw, 4.5rem);
+  line-height: 0.92;
+  letter-spacing: 0;
+  text-transform: uppercase;
+}
+
+.operator-header-meta {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.45rem;
+  min-width: min(420px, 100%);
+}
+
+.operator-header-meta span {
+  border: 1px solid rgba(244, 244, 240, 0.14);
+  background: rgba(255, 255, 255, 0.035);
+  padding: 0.65rem 0.75rem;
+  color: #d8ddd4;
+  font-size: 0.78rem;
+  text-transform: uppercase;
+}
+
+.operator-controls {
+  display: grid;
+  grid-template-columns: minmax(280px, 1.6fr) repeat(3, minmax(180px, 1fr));
+  gap: 0.75rem;
+  padding: 1.25rem 0;
+}
+
+.operator-controls label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  min-width: 0;
+}
+
+.operator-controls label > span {
+  color: rgba(244, 244, 240, 0.55);
+  font-size: 0.68rem;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+.operator-search {
+  position: relative;
+}
+
+.operator-search svg {
+  position: absolute;
+  left: 0.8rem;
+  bottom: 0.78rem;
+  color: #78dcca;
+}
+
+.operator-controls input,
+.operator-controls select {
+  width: 100%;
+  height: 2.75rem;
+  border: 1px solid rgba(244, 244, 240, 0.18);
+  border-radius: 0;
+  background: rgba(0, 0, 0, 0.56);
+  color: #ffffff;
+  font: inherit;
+  font-size: 0.85rem;
+  letter-spacing: 0;
+}
+
+.operator-controls input {
+  padding: 0 0.85rem 0 2.25rem;
+}
+
+.operator-controls select {
+  padding: 0 0.75rem;
+}
+
+.operator-table-wrap {
+  width: 100%;
+  border-top: 1px solid rgba(244, 244, 240, 0.16);
+  overflow-x: visible;
+}
+
+.operator-table {
+  width: 100%;
+  min-width: 0;
+  border-collapse: collapse;
+  table-layout: fixed;
+}
+
+.operator-table th,
+.operator-table td {
+  padding: 0.95rem 0.8rem;
+  border-bottom: 1px solid rgba(244, 244, 240, 0.11);
+  text-align: left;
+  vertical-align: top;
+  font-size: 0.82rem;
+  overflow-wrap: anywhere;
+}
+
+.operator-table th {
+  color: rgba(244, 244, 240, 0.55);
+  font-size: 0.68rem;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+
+.operator-table th:nth-child(1),
+.operator-table td:nth-child(1) {
+  width: 18%;
+}
+
+.operator-table th:nth-child(2),
+.operator-table td:nth-child(2) {
+  width: 17%;
+}
+
+.operator-table th:nth-child(3),
+.operator-table td:nth-child(3) {
+  width: 10%;
+}
+
+.operator-table th:nth-child(4),
+.operator-table td:nth-child(4) {
+  width: 11%;
+}
+
+.operator-table th:nth-child(5),
+.operator-table td:nth-child(5) {
+  width: 13%;
+}
+
+.operator-table th:nth-child(6),
+.operator-table td:nth-child(6) {
+  width: 17%;
+}
+
+.operator-table th:nth-child(7),
+.operator-table td:nth-child(7) {
+  width: 14%;
+}
+
+.operator-table tbody tr {
+  transition: background 0.16s ease, color 0.16s ease;
+}
+
+.operator-table tbody tr:hover {
+  background: rgba(120, 220, 202, 0.055);
+}
+
+.operator-title-link,
+.operator-route,
+.operator-open-route,
+.operator-back-link,
+.operator-detail-nav a {
+  color: #ffffff;
+  text-decoration: none;
+}
+
+.operator-title-link {
+  display: inline-block;
+  max-width: 260px;
+  color: #f4f4f0;
+  font-weight: 600;
+  text-transform: uppercase;
+}
+
+.operator-title-link:hover,
+.operator-route:hover,
+.operator-open-route:hover,
+.operator-back-link:hover,
+.operator-detail-nav a:hover {
+  color: #78dcca;
+}
+
+.operator-release {
+  display: block;
+  margin-top: 0.35rem;
+  color: rgba(244, 244, 240, 0.48);
+  font-size: 0.72rem;
+  text-transform: uppercase;
+}
+
+.operator-route,
+.operator-open-route,
+.operator-back-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+}
+
+.operator-route {
+  color: #9adfc5;
+  white-space: normal;
+  overflow-wrap: anywhere;
+}
+
+.operator-route svg {
+  flex: 0 0 auto;
+}
+
+.operator-status {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  white-space: nowrap;
+}
+
+.operator-status::before {
+  content: '';
+  width: 0.55rem;
+  height: 0.55rem;
+  border-radius: 999px;
+  background: #7f8a85;
+}
+
+.operator-status-active::before {
+  background: #78dcca;
+  box-shadow: 0 0 12px rgba(120, 220, 202, 0.55);
+}
+
+.operator-status-wip::before {
+  background: #f4c95d;
+}
+
+.operator-status-archived::before {
+  background: #7f8a85;
+}
+
+.operator-status-broken::before {
+  background: #ef5a4f;
+}
+
+.operator-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+}
+
+.operator-tags span {
+  display: inline-flex;
+  max-width: 100%;
+  border: 1px solid rgba(120, 220, 202, 0.28);
+  padding: 0.28rem 0.45rem;
+  color: #bfe9df;
+  font-size: 0.7rem;
+  line-height: 1.1;
+  overflow-wrap: anywhere;
+  text-transform: uppercase;
+}
+
+.operator-empty {
+  padding: 2rem;
+  border-bottom: 1px solid rgba(244, 244, 240, 0.11);
+  color: rgba(244, 244, 240, 0.66);
+  text-align: center;
+  letter-spacing: 0.14em;
+}
+
+.operator-detail-shell {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.operator-back-link {
+  width: fit-content;
+  color: #9adfc5;
+  font-size: 0.78rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+.operator-open-route {
+  border: 1px solid rgba(120, 220, 202, 0.34);
+  padding: 0.75rem 0.9rem;
+  color: #bfe9df;
+  font-size: 0.78rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+
+.operator-detail-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  border-top: 1px solid rgba(244, 244, 240, 0.14);
+  border-left: 1px solid rgba(244, 244, 240, 0.14);
+}
+
+.operator-detail-grid div {
+  min-width: 0;
+  padding: 1rem;
+  border-right: 1px solid rgba(244, 244, 240, 0.14);
+  border-bottom: 1px solid rgba(244, 244, 240, 0.14);
+}
+
+.operator-detail-grid span,
+.operator-detail-band h2 {
+  display: block;
+  margin: 0 0 0.45rem;
+  color: rgba(244, 244, 240, 0.5);
+  font-size: 0.68rem;
+  font-weight: 400;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+.operator-detail-grid strong {
+  display: block;
+  color: #ffffff;
+  font-size: 0.9rem;
+  font-weight: 600;
+  overflow-wrap: anywhere;
+}
+
+.operator-detail-band {
+  padding: 1.1rem 0;
+  border-top: 1px solid rgba(244, 244, 240, 0.14);
+}
+
+.operator-detail-band p {
+  max-width: 820px;
+  margin: 0;
+  color: #d8ddd4;
+  font-size: 0.95rem;
+  line-height: 1.6;
+}
+
+.operator-capability-list {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0;
+  margin: 0;
+  border-top: 1px solid rgba(244, 244, 240, 0.12);
+  border-left: 1px solid rgba(244, 244, 240, 0.12);
+}
+
+.operator-capability-list div {
+  min-width: 0;
+  padding: 0.8rem;
+  border-right: 1px solid rgba(244, 244, 240, 0.12);
+  border-bottom: 1px solid rgba(244, 244, 240, 0.12);
+}
+
+.operator-capability-list dt,
+.operator-launch-links h3 {
+  margin: 0 0 0.35rem;
+  color: rgba(244, 244, 240, 0.5);
+  font-size: 0.66rem;
+  font-weight: 400;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+.operator-capability-list dd {
+  margin: 0;
+  color: #ffffff;
+  font-size: 0.84rem;
+  overflow-wrap: anywhere;
+}
+
+.operator-launch-links {
+  margin-top: 1rem;
+}
+
+.operator-launch-links > div {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.operator-launch-links a {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  border: 1px solid rgba(120, 220, 202, 0.28);
+  padding: 0.45rem 0.65rem;
+  color: #bfe9df;
+  font-size: 0.76rem;
+  line-height: 1.1;
+  text-decoration: none;
+  overflow-wrap: anywhere;
+}
+
+.operator-launch-links a:hover {
+  color: #ffffff;
+  border-color: rgba(120, 220, 202, 0.55);
+}
+
+.operator-tags-large span {
+  padding: 0.45rem 0.65rem;
+  font-size: 0.76rem;
+}
+
+.operator-detail-nav {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  padding-top: 1.1rem;
+  border-top: 1px solid rgba(244, 244, 240, 0.14);
+  font-size: 0.78rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.operator-empty-large {
+  padding: 4rem 1rem;
+  border: 1px solid rgba(244, 244, 240, 0.14);
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+@media (max-width: 920px) {
+  .operator-page {
+    min-height: calc(100dvh - 3rem);
+  }
+
+  .operator-header,
+  .operator-detail-header {
+    flex-direction: column;
+  }
+
+  .operator-header-meta,
+  .operator-controls,
+  .operator-detail-grid,
+  .operator-capability-list {
+    grid-template-columns: 1fr;
+  }
+
+  .operator-table {
+    min-width: 0;
+  }
+
+  .operator-table thead {
+    display: none;
+  }
+
+  .operator-table,
+  .operator-table tbody,
+  .operator-table tr,
+  .operator-table td {
+    display: block;
+    width: 100%;
+  }
+
+  .operator-table tr {
+    border-bottom: 1px solid rgba(244, 244, 240, 0.16);
+    padding: 0.8rem 0;
+  }
+
+  .operator-table td {
+    display: grid;
+    grid-template-columns: minmax(7rem, 0.38fr) minmax(0, 1fr);
+    gap: 1rem;
+    border-bottom: 0;
+    padding: 0.45rem 0;
+  }
+
+  .operator-table td::before {
+    content: attr(data-label);
+    color: rgba(244, 244, 240, 0.48);
+    font-size: 0.68rem;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+  }
+
+  .operator-title-link {
+    max-width: 100%;
+  }
+
+  .operator-detail-nav {
+    flex-direction: column;
+  }
+}
+
+@media (max-width: 520px) {
+  .operator-header h1,
+  .operator-detail-header h1 {
+    font-size: 2.35rem;
+  }
+
+  .operator-header-meta span,
+  .operator-controls input,
+  .operator-controls select,
+  .operator-table td,
+  .operator-detail-grid strong,
+  .operator-detail-band p {
+    font-size: 0.8rem;
+  }
+
+  .operator-table td {
+    grid-template-columns: 1fr;
+    gap: 0.25rem;
+  }
+}

--- a/src/components/Operator/OperatorIndex.tsx
+++ b/src/components/Operator/OperatorIndex.tsx
@@ -1,0 +1,268 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { Link } from 'react-router-dom';
+import { ExternalLink, Search } from 'lucide-react';
+import {
+  Transmission,
+  TransmissionStatus,
+  TransmissionType,
+  TransmissionVisibility,
+  transmissions,
+} from '../../data/transmissions';
+import './Operator.css';
+
+type FilterValue<T extends string> = T | 'all';
+
+const typeOptions: Array<FilterValue<TransmissionType>> = [
+  'all',
+  'visual',
+  'interactive',
+  'release',
+  'artifact',
+  'page',
+  'commerce',
+];
+
+const statusOptions: Array<FilterValue<TransmissionStatus>> = [
+  'all',
+  'active',
+  'wip',
+  'archived',
+  'broken',
+];
+
+const visibilityOptions: Array<FilterValue<TransmissionVisibility>> = [
+  'all',
+  'public',
+  'soft-secret',
+  'operator-only',
+  'deprecated',
+];
+
+const formatLabel = (value: string) => value.replace(/-/g, ' ').toUpperCase();
+
+const formatExportCapability = (transmission: Transmission) => {
+  if (!transmission.visualExport) {
+    return '—';
+  }
+
+  const targets = transmission.visualExport.supportedTargets.join(', ');
+  return transmission.visualExport.hardwareFeedSafe ? `${targets} · HFS` : targets;
+};
+
+const matchesQuery = (transmission: Transmission, query: string) => {
+  const normalized = query.trim().toLowerCase();
+
+  if (!normalized) {
+    return true;
+  }
+
+  const searchable = [
+    transmission.slug,
+    transmission.route,
+    transmission.title,
+    transmission.type,
+    transmission.status,
+    transmission.visibility,
+    transmission.release ?? '',
+    transmission.notes ?? '',
+    transmission.visualExport?.defaultTarget ?? '',
+    transmission.visualExport?.capture ?? '',
+    transmission.visualExport?.hardwareFeedSafe ? 'hfs hardware-feed-safe' : '',
+    transmission.visualExport?.operatorNotes ?? '',
+    ...transmission.tags,
+    ...transmission.exportUse,
+    ...(transmission.visualExport?.supportedTargets ?? []),
+    ...(transmission.visualExport?.aspectRatios.supported ?? []),
+  ].join(' ').toLowerCase();
+
+  return searchable.includes(normalized);
+};
+
+export const OperatorIndex: React.FC = () => {
+  const [query, setQuery] = useState('');
+  const [typeFilter, setTypeFilter] = useState<FilterValue<TransmissionType>>('all');
+  const [statusFilter, setStatusFilter] = useState<FilterValue<TransmissionStatus>>('all');
+  const [visibilityFilter, setVisibilityFilter] = useState<FilterValue<TransmissionVisibility>>('all');
+
+  useEffect(() => {
+    const previousTitle = document.title;
+    const existingRobots = document.querySelector<HTMLMetaElement>('meta[name="robots"]');
+    const robotsMeta = existingRobots ?? document.createElement('meta');
+    const previousRobotsContent = existingRobots?.getAttribute('content');
+
+    document.title = 'Signal-23 Operator';
+    robotsMeta.setAttribute('name', 'robots');
+    robotsMeta.setAttribute('content', 'noindex,nofollow');
+
+    if (!existingRobots) {
+      document.head.appendChild(robotsMeta);
+    }
+
+    return () => {
+      document.title = previousTitle;
+
+      if (existingRobots && previousRobotsContent !== null && previousRobotsContent !== undefined) {
+        existingRobots.setAttribute('content', previousRobotsContent);
+      } else if (existingRobots) {
+        existingRobots.removeAttribute('content');
+      } else {
+        robotsMeta.remove();
+      }
+    };
+  }, []);
+
+  const filteredTransmissions = useMemo(
+    () =>
+      transmissions.filter((transmission) => {
+        const typeMatches = typeFilter === 'all' || transmission.type === typeFilter;
+        const statusMatches = statusFilter === 'all' || transmission.status === statusFilter;
+        const visibilityMatches = visibilityFilter === 'all' || transmission.visibility === visibilityFilter;
+
+        return typeMatches && statusMatches && visibilityMatches && matchesQuery(transmission, query);
+      }),
+    [query, statusFilter, typeFilter, visibilityFilter],
+  );
+
+  const counts = useMemo(
+    () => ({
+      total: transmissions.length,
+      active: transmissions.filter((transmission) => transmission.status === 'active').length,
+      softSecret: transmissions.filter((transmission) => transmission.visibility === 'soft-secret').length,
+      exports: transmissions.filter((transmission) => transmission.exportUse.length > 0).length,
+    }),
+    [],
+  );
+
+  return (
+    <main className="operator-page">
+      <section className="operator-shell" aria-labelledby="operator-title">
+        <header className="operator-header">
+          <div>
+            <p className="operator-kicker">S23 INTERNAL</p>
+            <h1 id="operator-title">OPERATOR MAP</h1>
+          </div>
+          <div className="operator-header-meta" aria-label="Registry totals">
+            <span>{counts.total} routes</span>
+            <span>{counts.active} active</span>
+            <span>{counts.softSecret} soft-secret</span>
+            <span>{counts.exports} export-ready</span>
+          </div>
+        </header>
+
+        <section className="operator-controls" aria-label="Transmission filters">
+          <label className="operator-search">
+            <Search size={16} aria-hidden="true" />
+            <span className="sr-only">Search transmissions</span>
+            <input
+              value={query}
+              onChange={(event) => setQuery(event.target.value)}
+              placeholder="SEARCH"
+              type="search"
+            />
+          </label>
+
+          <label>
+            <span>TYPE</span>
+            <select
+              value={typeFilter}
+              onChange={(event) => setTypeFilter(event.target.value as FilterValue<TransmissionType>)}
+            >
+              {typeOptions.map((option) => (
+                <option key={option} value={option}>
+                  {formatLabel(option)}
+                </option>
+              ))}
+            </select>
+          </label>
+
+          <label>
+            <span>STATUS</span>
+            <select
+              value={statusFilter}
+              onChange={(event) => setStatusFilter(event.target.value as FilterValue<TransmissionStatus>)}
+            >
+              {statusOptions.map((option) => (
+                <option key={option} value={option}>
+                  {formatLabel(option)}
+                </option>
+              ))}
+            </select>
+          </label>
+
+          <label>
+            <span>VISIBILITY</span>
+            <select
+              value={visibilityFilter}
+              onChange={(event) => setVisibilityFilter(event.target.value as FilterValue<TransmissionVisibility>)}
+            >
+              {visibilityOptions.map((option) => (
+                <option key={option} value={option}>
+                  {formatLabel(option)}
+                </option>
+              ))}
+            </select>
+          </label>
+        </section>
+
+        <section className="operator-table-wrap" aria-label="Transmission registry">
+          <table className="operator-table">
+            <thead>
+              <tr>
+                <th scope="col">SIGNAL</th>
+                <th scope="col">ROUTE</th>
+                <th scope="col">TYPE</th>
+                <th scope="col">STATUS</th>
+                <th scope="col">VISIBILITY</th>
+                <th scope="col">EXPORT</th>
+                <th scope="col">TAGS</th>
+              </tr>
+            </thead>
+            <tbody>
+              {filteredTransmissions.map((transmission) => (
+                <tr key={transmission.slug}>
+                  <td data-label="Signal">
+                    <Link className="operator-title-link" to={`/operator/transmissions/${transmission.slug}`}>
+                      {transmission.title}
+                    </Link>
+                    {transmission.release && (
+                      <span className="operator-release">{transmission.release}</span>
+                    )}
+                  </td>
+                  <td data-label="Route">
+                    <a className="operator-route" href={transmission.route} target="_blank" rel="noreferrer">
+                      {transmission.route}
+                      <ExternalLink size={13} aria-hidden="true" />
+                    </a>
+                  </td>
+                  <td data-label="Type">{formatLabel(transmission.type)}</td>
+                  <td data-label="Status">
+                    <span className={`operator-status operator-status-${transmission.status}`}>
+                      {formatLabel(transmission.status)}
+                    </span>
+                  </td>
+                  <td data-label="Visibility">{formatLabel(transmission.visibility)}</td>
+                  <td data-label="Export">
+                    {formatExportCapability(transmission)}
+                  </td>
+                  <td data-label="Tags">
+                    <div className="operator-tags">
+                      {transmission.tags.slice(0, 4).map((tag) => (
+                        <span key={tag}>{tag}</span>
+                      ))}
+                    </div>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+
+          {filteredTransmissions.length === 0 && (
+            <div className="operator-empty" role="status">
+              NO MATCHING TRANSMISSIONS
+            </div>
+          )}
+        </section>
+      </section>
+    </main>
+  );
+};

--- a/src/components/Operator/TransmissionDetail.tsx
+++ b/src/components/Operator/TransmissionDetail.tsx
@@ -1,0 +1,241 @@
+import React, { useEffect } from 'react';
+import { Link, useParams } from 'react-router-dom';
+import { ArrowLeft, ExternalLink } from 'lucide-react';
+import { getTransmissionBySlug, transmissions } from '../../data/transmissions';
+import './Operator.css';
+
+const formatLabel = (value: string) => value.replace(/-/g, ' ').toUpperCase();
+
+const formatAspect = (
+  aspect: string,
+  defaultAspect: string,
+) => (aspect === defaultAspect ? `${aspect} (default)` : aspect);
+
+const formatDuration = (duration: {
+  supported: boolean;
+  defaultSeconds?: number;
+  minSeconds?: number;
+  maxSeconds?: number;
+}) => {
+  if (!duration.supported) {
+    return 'indefinite';
+  }
+
+  const range = typeof duration.minSeconds === 'number' && typeof duration.maxSeconds === 'number'
+    ? `${duration.minSeconds}-${duration.maxSeconds}s`
+    : 'operator-set';
+  const defaultValue = typeof duration.defaultSeconds === 'number'
+    ? ` (default ${duration.defaultSeconds}s)`
+    : '';
+
+  return `${range}${defaultValue}`;
+};
+
+export const TransmissionDetail: React.FC = () => {
+  const { slug = '' } = useParams();
+  const transmission = getTransmissionBySlug(slug);
+  const index = transmission
+    ? transmissions.findIndex((candidate) => candidate.slug === transmission.slug)
+    : -1;
+  const previousTransmission = index > 0 ? transmissions[index - 1] : undefined;
+  const nextTransmission = index >= 0 && index < transmissions.length - 1 ? transmissions[index + 1] : undefined;
+
+  useEffect(() => {
+    const previousTitle = document.title;
+    const existingRobots = document.querySelector<HTMLMetaElement>('meta[name="robots"]');
+    const robotsMeta = existingRobots ?? document.createElement('meta');
+    const previousRobotsContent = existingRobots?.getAttribute('content');
+
+    document.title = transmission ? `${transmission.title} - Signal-23 Operator` : 'Signal-23 Operator';
+    robotsMeta.setAttribute('name', 'robots');
+    robotsMeta.setAttribute('content', 'noindex,nofollow');
+
+    if (!existingRobots) {
+      document.head.appendChild(robotsMeta);
+    }
+
+    return () => {
+      document.title = previousTitle;
+
+      if (existingRobots && previousRobotsContent !== null && previousRobotsContent !== undefined) {
+        existingRobots.setAttribute('content', previousRobotsContent);
+      } else if (existingRobots) {
+        existingRobots.removeAttribute('content');
+      } else {
+        robotsMeta.remove();
+      }
+    };
+  }, [transmission]);
+
+  if (!transmission) {
+    return (
+      <main className="operator-page">
+        <section className="operator-shell operator-detail-shell">
+          <Link className="operator-back-link" to="/operator">
+            <ArrowLeft size={16} aria-hidden="true" />
+            OPERATOR MAP
+          </Link>
+          <div className="operator-empty operator-empty-large" role="status">
+            TRANSMISSION NOT FOUND
+          </div>
+        </section>
+      </main>
+    );
+  }
+
+  return (
+    <main className="operator-page">
+      <article className="operator-shell operator-detail-shell">
+        <Link className="operator-back-link" to="/operator">
+          <ArrowLeft size={16} aria-hidden="true" />
+          OPERATOR MAP
+        </Link>
+
+        <header className="operator-detail-header">
+          <div>
+            <p className="operator-kicker">{formatLabel(transmission.visibility)}</p>
+            <h1>{transmission.title}</h1>
+          </div>
+          <a className="operator-open-route" href={transmission.route} target="_blank" rel="noreferrer">
+            OPEN ROUTE
+            <ExternalLink size={16} aria-hidden="true" />
+          </a>
+        </header>
+
+        <section className="operator-detail-grid" aria-label="Transmission metadata">
+          <div>
+            <span>SLUG</span>
+            <strong>{transmission.slug}</strong>
+          </div>
+          <div>
+            <span>ROUTE</span>
+            <strong>{transmission.route}</strong>
+          </div>
+          <div>
+            <span>TYPE</span>
+            <strong>{formatLabel(transmission.type)}</strong>
+          </div>
+          <div>
+            <span>STATUS</span>
+            <strong>{formatLabel(transmission.status)}</strong>
+          </div>
+          <div>
+            <span>RELEASE</span>
+            <strong>{transmission.release ?? 'UNASSIGNED'}</strong>
+          </div>
+          <div>
+            <span>ADDED</span>
+            <strong>{transmission.addedAt}</strong>
+          </div>
+        </section>
+
+        <section className="operator-detail-band" aria-label="Export targets">
+          <h2>EXPORT USE</h2>
+          <div className="operator-tags operator-tags-large">
+            {transmission.exportUse.length > 0 ? (
+              transmission.exportUse.map((target) => <span key={target}>{formatLabel(target)}</span>)
+            ) : (
+              <span>NONE</span>
+            )}
+          </div>
+        </section>
+
+        <section className="operator-detail-band" aria-label="Tags">
+          <h2>TAGS</h2>
+          <div className="operator-tags operator-tags-large">
+            {transmission.tags.map((tag) => (
+              <span key={tag}>{tag}</span>
+            ))}
+          </div>
+        </section>
+
+        {transmission.notes && (
+          <section className="operator-detail-band" aria-label="Notes">
+            <h2>NOTES</h2>
+            <p>{transmission.notes}</p>
+          </section>
+        )}
+
+        {transmission.visualExport && (
+          <section className="operator-detail-band" aria-label="Visual export capability">
+            <h2>EXPORT CAPABILITY</h2>
+            <dl className="operator-capability-list">
+              <div>
+                <dt>Targets</dt>
+                <dd>{transmission.visualExport.supportedTargets.join(', ')}</dd>
+              </div>
+              <div>
+                <dt>Default</dt>
+                <dd>{transmission.visualExport.defaultTarget}</dd>
+              </div>
+              <div>
+                <dt>Aspects</dt>
+                <dd>
+                  {transmission.visualExport.aspectRatios.supported
+                    .map((aspect) => formatAspect(aspect, transmission.visualExport!.aspectRatios.default))
+                    .join(', ')}
+                </dd>
+              </div>
+              <div>
+                <dt>Duration</dt>
+                <dd>{formatDuration(transmission.visualExport.duration)}</dd>
+              </div>
+              <div>
+                <dt>Seed</dt>
+                <dd>{transmission.visualExport.seed.supported ? 'supported' : 'not supported'}</dd>
+              </div>
+              <div>
+                <dt>Capture</dt>
+                <dd>{transmission.visualExport.capture}</dd>
+              </div>
+              <div>
+                <dt>Hardware-feed safe</dt>
+                <dd>{transmission.visualExport.hardwareFeedSafe ? 'yes' : 'no'}</dd>
+              </div>
+              {transmission.visualExport.operatorNotes && (
+                <div>
+                  <dt>Notes</dt>
+                  <dd>{transmission.visualExport.operatorNotes}</dd>
+                </div>
+              )}
+            </dl>
+
+            <div className="operator-launch-links" aria-label="Launch links">
+              <h3>LAUNCH LINKS</h3>
+              <div>
+                {transmission.visualExport.supportedTargets.map((target) => (
+                  <a
+                    key={target}
+                    href={`${transmission.route}?target=${target}`}
+                    target="_blank"
+                    rel="noopener"
+                  >
+                    {target}
+                    <ExternalLink size={13} aria-hidden="true" />
+                  </a>
+                ))}
+              </div>
+            </div>
+          </section>
+        )}
+
+        <nav className="operator-detail-nav" aria-label="Adjacent transmissions">
+          {previousTransmission ? (
+            <Link to={`/operator/transmissions/${previousTransmission.slug}`}>
+              PREV: {previousTransmission.title}
+            </Link>
+          ) : (
+            <span />
+          )}
+          {nextTransmission ? (
+            <Link to={`/operator/transmissions/${nextTransmission.slug}`}>
+              NEXT: {nextTransmission.title}
+            </Link>
+          ) : (
+            <span />
+          )}
+        </nav>
+      </article>
+    </main>
+  );
+};

--- a/src/components/Reclamation/Reclamation.css
+++ b/src/components/Reclamation/Reclamation.css
@@ -1,6 +1,6 @@
 .reclamation-container {
-    width: 100vw;
-    height: 100vh;
+    width: 100%;
+    height: 100%;
     margin: 0;
     padding: 0;
     overflow: hidden;

--- a/src/components/Reclamation/Reclamation.tsx
+++ b/src/components/Reclamation/Reclamation.tsx
@@ -4,6 +4,9 @@ import { EffectComposer } from 'three/examples/jsm/postprocessing/EffectComposer
 import { RenderPass } from 'three/examples/jsm/postprocessing/RenderPass';
 import { UnrealBloomPass } from 'three/examples/jsm/postprocessing/UnrealBloomPass';
 import { ShaderPass } from 'three/examples/jsm/postprocessing/ShaderPass';
+import { ExportFrame } from '../ExportFrame/ExportFrame';
+import { reclamationVisualExport } from '../../data/transmissions';
+import { useExportSettings } from '../../lib/exportSettings';
 import './Reclamation.css';
 
 // ── Cycle timing ─────────────────────────────────────────────────────────────
@@ -53,6 +56,7 @@ interface VineSegment {
 
 export const Reclamation: React.FC = () => {
     const mountRef = useRef<HTMLDivElement>(null);
+    const exportSettings = useExportSettings(reclamationVisualExport);
     const [logs, setLogs] = useState<string[]>([]);
     const logContainerRef = useRef<HTMLDivElement>(null);
     const [showText, setShowText] = useState(false);
@@ -127,40 +131,51 @@ export const Reclamation: React.FC = () => {
     useEffect(() => {
         if (!mountRef.current) return;
         let isComponentMounted = true;
+        const mountElement = mountRef.current;
 
-        const width = window.innerWidth;
-        const height = window.innerHeight;
-        const isMobile = width < 768;
+        const getMountSize = () => {
+            const rect = mountElement.getBoundingClientRect();
+            const width = rect.width || mountElement.clientWidth || window.innerWidth;
+            const height = rect.height || mountElement.clientHeight || window.innerHeight;
+
+            return {
+                width: Math.max(1, Math.floor(width)),
+                height: Math.max(1, Math.floor(height)),
+            };
+        };
+
+        const initialSize = getMountSize();
+        let mountAspect = initialSize.width / initialSize.height;
+        let isMobile = initialSize.width < 768;
 
         // ── Scene ────────────────────────────────────────────────────────
         const scene = new THREE.Scene();
         scene.fog = new THREE.FogExp2(0x000000, 0.006);
 
-        const camera = new THREE.PerspectiveCamera(55, width / height, 0.1, 2000);
+        const camera = new THREE.PerspectiveCamera(
+            55,
+            initialSize.width / initialSize.height,
+            0.1,
+            2000
+        );
         camera.position.set(0, 30, 180);
 
         const renderer = new THREE.WebGLRenderer({ antialias: true, alpha: true });
-        renderer.setSize(width, height);
+        renderer.setSize(initialSize.width, initialSize.height);
         renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
         renderer.toneMapping = THREE.ReinhardToneMapping;
         renderer.toneMappingExposure = 1.1;
-        mountRef.current.appendChild(renderer.domElement);
+        mountElement.appendChild(renderer.domElement);
         canvasRef.current = renderer.domElement;
 
         const handleContextLost = (event: Event) => event.preventDefault();
-        const handleContextRestored = () => {
-            renderer.setSize(window.innerWidth, window.innerHeight);
-            composer.setSize(window.innerWidth, window.innerHeight);
-        };
-        renderer.domElement.addEventListener('webglcontextlost', handleContextLost);
-        renderer.domElement.addEventListener('webglcontextrestored', handleContextRestored);
 
         // ── Post-processing ──────────────────────────────────────────────
         const composer = new EffectComposer(renderer);
         composer.addPass(new RenderPass(scene, camera));
 
         const bloomPass = new UnrealBloomPass(
-            new THREE.Vector2(width, height),
+            new THREE.Vector2(initialSize.width, initialSize.height),
             0.7,
             0.6,
             0.25
@@ -453,16 +468,27 @@ export const Reclamation: React.FC = () => {
         };
 
         // ── Resize ───────────────────────────────────────────────────────
-        const handleResize = () => {
-            const w = window.innerWidth;
-            const h = window.innerHeight;
-            camera.aspect = w / h;
+        const resizeToMount = () => {
+            const { width, height } = getMountSize();
+            mountAspect = width / height;
+            isMobile = width < 768;
+            camera.aspect = mountAspect;
             camera.updateProjectionMatrix();
-            renderer.setSize(w, h);
-            composer.setSize(w, h);
-            bloomPass.resolution.set(w, h);
+            renderer.setSize(width, height);
+            composer.setSize(width, height);
+            bloomPass.resolution.set(width, height);
         };
-        window.addEventListener('resize', handleResize);
+
+        const handleContextRestored = () => {
+            resizeToMount();
+        };
+        renderer.domElement.addEventListener('webglcontextlost', handleContextLost);
+        renderer.domElement.addEventListener('webglcontextrestored', handleContextRestored);
+
+        resizeToMount();
+
+        const resizeObserver = new ResizeObserver(resizeToMount);
+        resizeObserver.observe(mountElement);
 
         // ── Animation ────────────────────────────────────────────────────
         let animationId = 0;
@@ -597,7 +623,7 @@ export const Reclamation: React.FC = () => {
             bloomPass.strength = 0.6 + growthProgress * 0.85;
 
             // Camera — meditative orbit, rises as bloom peaks
-            const orbitRadius = isMobile ? 220 : 175;
+            const orbitRadius = mountAspect < 0.8 ? 300 : isMobile ? 220 : 175;
             const orbitSpeed = 0.045;
             camera.position.x = Math.sin(time * orbitSpeed) * orbitRadius;
             camera.position.z = Math.cos(time * orbitSpeed) * orbitRadius;
@@ -621,7 +647,7 @@ export const Reclamation: React.FC = () => {
         return () => {
             isComponentMounted = false;
             if (animationId) cancelAnimationFrame(animationId);
-            window.removeEventListener('resize', handleResize);
+            resizeObserver.disconnect();
             renderer.domElement.removeEventListener('webglcontextlost', handleContextLost);
             renderer.domElement.removeEventListener('webglcontextrestored', handleContextRestored);
             composer.dispose();
@@ -640,14 +666,14 @@ export const Reclamation: React.FC = () => {
             glowTexture.dispose();
             renderer.dispose();
             if (
-                mountRef.current &&
+                mountElement &&
                 renderer.domElement &&
-                mountRef.current.contains(renderer.domElement)
+                mountElement.contains(renderer.domElement)
             ) {
-                mountRef.current.removeChild(renderer.domElement);
+                mountElement.removeChild(renderer.domElement);
             }
         };
-    }, []);
+    }, [exportSettings.isExportMode]);
 
     // Log simulation (toggle-visible HUD)
     useEffect(() => {
@@ -683,38 +709,44 @@ export const Reclamation: React.FC = () => {
     }, []);
 
     return (
-        <div
-            className="reclamation-container"
-            onClick={() => setShowText((p) => !p)}
-        >
-            <div ref={mountRef} className="reclamation-canvas" />
+        <ExportFrame aspect={exportSettings.aspect} active={exportSettings.isExportMode}>
+            <div
+                className="reclamation-container"
+                onClick={() => {
+                    if (!exportSettings.isExportMode) {
+                        setShowText((p) => !p);
+                    }
+                }}
+            >
+                <div ref={mountRef} className="reclamation-canvas" />
 
-            {process.env.NODE_ENV !== 'production' && (
-                <button
-                    className={`record-button ${isRecording ? 'recording' : ''}`}
-                    onClick={toggleRecording}
-                    title={isRecording ? 'Stop Recording' : 'Start Recording'}
-                >
-                    <span className="record-icon" />
-                    {isRecording && (
-                        <span className="record-time">{formatTime(recordingTime)}</span>
-                    )}
-                </button>
-            )}
+                {process.env.NODE_ENV !== 'production' && !exportSettings.isExportMode && (
+                    <button
+                        className={`record-button ${isRecording ? 'recording' : ''}`}
+                        onClick={toggleRecording}
+                        title={isRecording ? 'Stop Recording' : 'Start Recording'}
+                    >
+                        <span className="record-icon" />
+                        {isRecording && (
+                            <span className="record-time">{formatTime(recordingTime)}</span>
+                        )}
+                    </button>
+                )}
 
-            {showText && (
-                <div className="reclamation-hud">
-                    <div className="reclamation-hud-bottom">
-                        <div className="reclamation-logs" ref={logContainerRef}>
-                            {logs.map((log, i) => (
-                                <div key={i} className="log-entry">
-                                    {log}
-                                </div>
-                            ))}
+                {showText && !exportSettings.isExportMode && (
+                    <div className="reclamation-hud">
+                        <div className="reclamation-hud-bottom">
+                            <div className="reclamation-logs" ref={logContainerRef}>
+                                {logs.map((log, i) => (
+                                    <div key={i} className="log-entry">
+                                        {log}
+                                    </div>
+                                ))}
+                            </div>
                         </div>
                     </div>
-                </div>
-            )}
-        </div>
+                )}
+            </div>
+        </ExportFrame>
     );
 };

--- a/src/components/Resonance/Resonance.css
+++ b/src/components/Resonance/Resonance.css
@@ -15,6 +15,8 @@
     position: absolute;
     top: 0;
     left: 0;
+    width: 100%;
+    height: 100%;
     z-index: 1;
     display: block;
 }
@@ -77,8 +79,9 @@
 }
 
 .resonance-container {
-    width: 100vw;
-    height: 100vh;
+    position: relative;
+    width: 100%;
+    height: 100%;
     overflow: hidden;
     font-family: 'IBM Plex Mono', monospace;
     font-size: 9px;

--- a/src/components/Resonance/Resonance.tsx
+++ b/src/components/Resonance/Resonance.tsx
@@ -1,5 +1,8 @@
 import React, { useEffect, useRef, useState } from 'react';
 import * as THREE from 'three';
+import { ExportFrame } from '../ExportFrame/ExportFrame';
+import { resonanceVisualExport } from '../../data/transmissions';
+import { useExportSettings } from '../../lib/exportSettings';
 import './Resonance.css';
 
 const LOG_MESSAGES = [
@@ -18,6 +21,7 @@ const LOG_MESSAGES = [
 
 export const Resonance: React.FC = () => {
     const mountRef = useRef<HTMLDivElement>(null);
+    const exportSettings = useExportSettings(resonanceVisualExport);
     const [logs, setLogs] = useState<string[]>([]);
     const logContainerRef = useRef<HTMLDivElement>(null);
     const [showText, setShowText] = useState(false);
@@ -101,17 +105,29 @@ export const Resonance: React.FC = () => {
     // Neural Network Simulation Logic
     useEffect(() => {
         if (!mountRef.current) return;
+        const mountElement = mountRef.current;
 
-        const width = window.innerWidth;
-        const height = window.innerHeight;
+        const getMountSize = () => {
+            const rect = mountElement.getBoundingClientRect();
+            const width = rect.width || mountElement.clientWidth || window.innerWidth;
+            const height = rect.height || mountElement.clientHeight || window.innerHeight;
+
+            return {
+                width: Math.max(1, Math.floor(width)),
+                height: Math.max(1, Math.floor(height)),
+            };
+        };
+
+        const initialSize = getMountSize();
+        let mountWidth = initialSize.width;
 
         // Scene setup
         const scene = new THREE.Scene();
-        const camera = new THREE.PerspectiveCamera(75, width / height, 0.1, 1000);
+        const camera = new THREE.PerspectiveCamera(75, initialSize.width / initialSize.height, 0.1, 1000);
         const renderer = new THREE.WebGLRenderer({ antialias: true, alpha: true });
-        renderer.setSize(width, height);
+        renderer.setSize(initialSize.width, initialSize.height);
         renderer.setPixelRatio(window.devicePixelRatio);
-        mountRef.current.appendChild(renderer.domElement);
+        mountElement.appendChild(renderer.domElement);
         canvasRef.current = renderer.domElement;
 
         // Helper to create a circular glow texture
@@ -253,13 +269,14 @@ export const Resonance: React.FC = () => {
         const resizeObserver = new ResizeObserver((entries) => {
             for (let entry of entries) {
                 const { width, height } = entry.contentRect;
+                mountWidth = width;
                 camera.aspect = width / height;
                 camera.updateProjectionMatrix();
                 renderer.setSize(width, height);
             }
         });
 
-        if (mountRef.current) resizeObserver.observe(mountRef.current);
+        resizeObserver.observe(mountElement);
 
         // Animation
         let animationId: number;
@@ -309,7 +326,7 @@ export const Resonance: React.FC = () => {
             }
             lineGeom.attributes.position.needsUpdate = true;
 
-            const isMobile = window.innerWidth < 768;
+            const isMobile = mountWidth < 768;
             camera.position.x = Math.sin(time * 0.15) * 45 * (isMobile ? 1.5 : 1.0);
             camera.position.y = Math.cos(time * 0.1) * 35 * (isMobile ? 1.5 : 1.0);
             camera.position.z = 50 + Math.sin(time * 0.2) * 15;
@@ -338,12 +355,12 @@ export const Resonance: React.FC = () => {
 
             scene.clear();
 
-            if (mountRef.current && renderer.domElement) {
-                mountRef.current.removeChild(renderer.domElement);
+            if (mountElement && renderer.domElement && mountElement.contains(renderer.domElement)) {
+                mountElement.removeChild(renderer.domElement);
             }
             renderer.dispose();
         };
-    }, []);
+    }, [exportSettings.isExportMode]);
 
     // Algorithm Learning Logs simulation
     useEffect(() => {
@@ -380,33 +397,42 @@ export const Resonance: React.FC = () => {
     }, []);
 
     return (
-        <div className="resonance-container" onClick={() => setShowText(prev => !prev)}>
-            <div ref={mountRef} className="nn-canvas" />
+        <ExportFrame aspect={exportSettings.aspect} active={exportSettings.isExportMode}>
+            <div
+                className="resonance-container"
+                onClick={() => {
+                    if (!exportSettings.isExportMode) {
+                        setShowText(prev => !prev);
+                    }
+                }}
+            >
+                <div ref={mountRef} className="nn-canvas" />
 
-            {/* Record Button - Dev only */}
-            {process.env.NODE_ENV !== 'production' && (
-                <button
-                    className={`record-button ${isRecording ? 'recording' : ''}`}
-                    onClick={toggleRecording}
-                    title={isRecording ? 'Stop Recording' : 'Start Recording'}
-                >
-                    <span className="record-icon" />
-                    {isRecording && <span className="record-time">{formatTime(recordingTime)}</span>}
-                </button>
-            )}
+                {/* Record Button - Dev only */}
+                {process.env.NODE_ENV !== 'production' && !exportSettings.isExportMode && (
+                    <button
+                        className={`record-button ${isRecording ? 'recording' : ''}`}
+                        onClick={toggleRecording}
+                        title={isRecording ? 'Stop Recording' : 'Start Recording'}
+                    >
+                        <span className="record-icon" />
+                        {isRecording && <span className="record-time">{formatTime(recordingTime)}</span>}
+                    </button>
+                )}
 
-            {showText && (
-                <div className="test-hud">
-                    {/* Bottom-Right Logs */}
-                    <div className="test-hud-bottom">
-                        <div className="learning-logs" ref={logContainerRef}>
-                            {logs.map((log, i) => (
-                                <div key={i} className="log-entry">{log}</div>
-                            ))}
+                {showText && !exportSettings.isExportMode && (
+                    <div className="test-hud">
+                        {/* Bottom-Right Logs */}
+                        <div className="test-hud-bottom">
+                            <div className="learning-logs" ref={logContainerRef}>
+                                {logs.map((log, i) => (
+                                    <div key={i} className="log-entry">{log}</div>
+                                ))}
+                            </div>
                         </div>
                     </div>
-                </div>
-            )}
-        </div>
+                )}
+            </div>
+        </ExportFrame>
     );
 };

--- a/src/components/Stepwell/Stepwell.css
+++ b/src/components/Stepwell/Stepwell.css
@@ -1,9 +1,7 @@
 @import url('https://fonts.googleapis.com/css2?family=Space+Mono:wght@400;700&display=swap');
 
 .stepwell-container {
-    position: fixed;
-    top: 0;
-    left: 0;
+    position: relative;
     width: 100%;
     height: 100%;
     background-color: #050505;

--- a/src/components/Stepwell/Stepwell.tsx
+++ b/src/components/Stepwell/Stepwell.tsx
@@ -5,6 +5,9 @@ import { RenderPass } from 'three/examples/jsm/postprocessing/RenderPass';
 import { UnrealBloomPass } from 'three/examples/jsm/postprocessing/UnrealBloomPass';
 import { ShaderPass } from 'three/examples/jsm/postprocessing/ShaderPass';
 import { gsap } from 'gsap';
+import { ExportFrame } from '../ExportFrame/ExportFrame';
+import { stepwellVisualExport } from '../../data/transmissions';
+import { useExportSettings } from '../../lib/exportSettings';
 import './Stepwell.css';
 
 // --- Custom Fog Shader ---
@@ -110,6 +113,7 @@ const WALL_THICKNESS = 15;
 
 export const Stepwell: React.FC = () => {
     const mountRef = useRef<HTMLDivElement>(null);
+    const exportSettings = useExportSettings(stepwellVisualExport);
     const rendererRef = useRef<THREE.WebGLRenderer | null>(null);
     const sceneRef = useRef<THREE.Scene | null>(null);
     const cameraRef = useRef<THREE.PerspectiveCamera | null>(null);
@@ -128,30 +132,41 @@ export const Stepwell: React.FC = () => {
 
     useEffect(() => {
         if (!mountRef.current) return;
+        const mountElement = mountRef.current;
 
-        const width = mountRef.current.clientWidth;
-        const height = mountRef.current.clientHeight;
+        const getMountSize = () => {
+            const rect = mountElement.getBoundingClientRect();
+            const width = rect.width || mountElement.clientWidth || window.innerWidth;
+            const height = rect.height || mountElement.clientHeight || window.innerHeight;
+
+            return {
+                width: Math.max(1, Math.floor(width)),
+                height: Math.max(1, Math.floor(height)),
+            };
+        };
+
+        const initialSize = getMountSize();
 
         // --- Renderer ---
         const renderer = new THREE.WebGLRenderer({ antialias: false, powerPreference: "high-performance" });
-        renderer.setSize(width, height);
+        renderer.setSize(initialSize.width, initialSize.height);
         renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
         renderer.setClearColor(0x050505);
-        mountRef.current.appendChild(renderer.domElement);
+        mountElement.appendChild(renderer.domElement);
         rendererRef.current = renderer;
 
         // --- Scene & Camera ---
         const scene = new THREE.Scene();
         sceneRef.current = scene;
 
-        const camera = new THREE.PerspectiveCamera(60, width / height, 0.1, 1000);
+        const camera = new THREE.PerspectiveCamera(60, initialSize.width / initialSize.height, 0.1, 1000);
         camera.position.set(0, 50, 0);
         camera.lookAt(0, 0, 0);
         cameraRef.current = camera;
 
         // Depth texture for custom fog
-        const depthTexture = new THREE.DepthTexture(width, height);
-        const renderTarget = new THREE.WebGLRenderTarget(width, height, {
+        const depthTexture = new THREE.DepthTexture(initialSize.width, initialSize.height);
+        const renderTarget = new THREE.WebGLRenderTarget(initialSize.width, initialSize.height, {
             depthBuffer: true,
             stencilBuffer: false
         });
@@ -168,7 +183,7 @@ export const Stepwell: React.FC = () => {
         fogPass.uniforms.tDepth.value = depthTexture;
         composer.addPass(fogPass);
 
-        const bloomPass = new UnrealBloomPass(new THREE.Vector2(width, height), 1.5, 0.4, 0.85);
+        const bloomPass = new UnrealBloomPass(new THREE.Vector2(initialSize.width, initialSize.height), 1.5, 0.4, 0.85);
         composer.addPass(bloomPass);
 
         const grainPass = new ShaderPass(FilmGrainShader);
@@ -334,18 +349,20 @@ export const Stepwell: React.FC = () => {
 
         requestAnimationFrame(animate);
 
-        const handleResize = () => {
-            const w = mountRef.current?.clientWidth || window.innerWidth;
-            const h = mountRef.current?.clientHeight || window.innerHeight;
-            camera.aspect = w / h;
+        const resizeToMount = () => {
+            const { width, height } = getMountSize();
+            camera.aspect = width / height;
             camera.updateProjectionMatrix();
-            renderer.setSize(w, h);
-            composer.setSize(w, h);
+            renderer.setSize(width, height);
+            composer.setSize(width, height);
         };
-        window.addEventListener('resize', handleResize);
+        resizeToMount();
+
+        const resizeObserver = new ResizeObserver(resizeToMount);
+        resizeObserver.observe(mountElement);
 
         return () => {
-            window.removeEventListener('resize', handleResize);
+            resizeObserver.disconnect();
             cancelAnimationFrame(animId);
             driftTween.kill();
 
@@ -376,12 +393,12 @@ export const Stepwell: React.FC = () => {
             // Dispose post-processing
             composer.dispose();
 
-            if (mountRef.current && renderer.domElement) {
-                mountRef.current.removeChild(renderer.domElement);
+            if (mountElement && renderer.domElement && mountElement.contains(renderer.domElement)) {
+                mountElement.removeChild(renderer.domElement);
             }
             renderer.dispose();
         };
-    }, []);
+    }, [exportSettings.isExportMode]);
 
     // Log simulation
     useEffect(() => {
@@ -396,42 +413,45 @@ export const Stepwell: React.FC = () => {
     }, []);
 
     return (
-        <div className="stepwell-container">
-            <div ref={mountRef} className="stepwell-canvas" />
+        <ExportFrame aspect={exportSettings.aspect} active={exportSettings.isExportMode}>
+            <div className="stepwell-container">
+                <div ref={mountRef} className="stepwell-canvas" />
 
-            <div className="stepwell-ui">
-                <div className="ui-header">
-                    <span className="scrolling-text">STEPWELL // RECURSIVE ARCHITECTURE // DEPTH ANALYSIS // BRUTALIST DESCENT</span>
-                </div>
+                {!exportSettings.isExportMode && (
+                    <div className="stepwell-ui">
+                        <div className="ui-header">
+                            <span className="scrolling-text">STEPWELL // RECURSIVE ARCHITECTURE // DEPTH ANALYSIS // BRUTALIST DESCENT</span>
+                        </div>
 
-                <div className="ui-coords">
-                    <div className="coord-item">
-                        <span className="label">POS_X</span>
-                        <span className="value">{coords.x.toFixed(4)}</span>
+                        <div className="ui-coords">
+                            <div className="coord-item">
+                                <span className="label">POS_X</span>
+                                <span className="value">{coords.x.toFixed(4)}</span>
+                            </div>
+                            <div className="coord-item">
+                                <span className="label">POS_Y</span>
+                                <span className="value">{coords.y.toFixed(4)}</span>
+                            </div>
+                            <div className="coord-item">
+                                <span className="label">POS_Z</span>
+                                <span className="value">{coords.z.toFixed(4)}</span>
+                            </div>
+                        </div>
+
+                        <div className="ui-logs">
+                            {logs.map((log, i) => (
+                                <div key={i} className="log-entry">{log}</div>
+                            ))}
+                        </div>
+
+                        <div className="ui-footer">
+                            SIGNAL-23 SYSTEM STATUS: <span className="status-ok">OPERATIONAL</span>
+                        </div>
                     </div>
-                    <div className="coord-item">
-                        <span className="label">POS_Y</span>
-                        <span className="value">{coords.y.toFixed(4)}</span>
-                    </div>
-                    <div className="coord-item">
-                        <span className="label">POS_Z</span>
-                        <span className="value">{coords.z.toFixed(4)}</span>
-                    </div>
-                </div>
+                )}
 
-                <div className="ui-logs">
-                    {logs.map((log, i) => (
-                        <div key={i} className="log-entry">{log}</div>
-                    ))}
-                </div>
-
-                <div className="ui-footer">
-                    SIGNAL-23 SYSTEM STATUS: <span className="status-ok">OPERATIONAL</span>
-                </div>
+                <div className="vignette" />
             </div>
-
-            <div className="vignette" />
-        </div>
+        </ExportFrame>
     );
 };
-

--- a/src/components/Tangle/Tangle.css
+++ b/src/components/Tangle/Tangle.css
@@ -1,7 +1,7 @@
 .tangle-container {
   position: relative;
-  width: 100vw;
-  height: 100vh;
+  width: 100%;
+  height: 100%;
   background: #000;
   overflow: hidden;
   font-family: 'IBM Plex Mono', monospace;

--- a/src/components/Tangle/Tangle.tsx
+++ b/src/components/Tangle/Tangle.tsx
@@ -1,5 +1,8 @@
 import React, { useEffect, useRef, useState } from 'react';
 import * as THREE from 'three';
+import { ExportFrame } from '../ExportFrame/ExportFrame';
+import { tangleVisualExport } from '../../data/transmissions';
+import { useExportSettings } from '../../lib/exportSettings';
 import './Tangle.css';
 
 const QUANTUM_MESSAGES = [
@@ -29,6 +32,7 @@ const SIGNAL_STATES = [
 
 export const Tangle: React.FC = () => {
   const mountRef = useRef<HTMLDivElement>(null);
+  const exportSettings = useExportSettings(tangleVisualExport);
   const [logs, setLogs] = useState<string[]>([]);
   const logContainerRef = useRef<HTMLDivElement>(null);
   const [quantumState, setQuantumState] = useState(0);
@@ -112,16 +116,28 @@ export const Tangle: React.FC = () => {
   // Three.js visualization
   useEffect(() => {
     if (!mountRef.current) return;
+    const mountElement = mountRef.current;
 
-    const width = window.innerWidth;
-    const height = window.innerHeight;
+    const getMountSize = () => {
+      const rect = mountElement.getBoundingClientRect();
+      const width = rect.width || mountElement.clientWidth || window.innerWidth;
+      const height = rect.height || mountElement.clientHeight || window.innerHeight;
+
+      return {
+        width: Math.max(1, Math.floor(width)),
+        height: Math.max(1, Math.floor(height)),
+      };
+    };
+
+    const initialSize = getMountSize();
+    let mountWidth = initialSize.width;
 
     const scene = new THREE.Scene();
-    const camera = new THREE.PerspectiveCamera(75, width / height, 0.1, 1000);
+    const camera = new THREE.PerspectiveCamera(75, initialSize.width / initialSize.height, 0.1, 1000);
     const renderer = new THREE.WebGLRenderer({ antialias: true, alpha: true });
-    renderer.setSize(width, height);
+    renderer.setSize(initialSize.width, initialSize.height);
     renderer.setPixelRatio(window.devicePixelRatio);
-    mountRef.current.appendChild(renderer.domElement);
+    mountElement.appendChild(renderer.domElement);
     canvasRef.current = renderer.domElement;
 
     // --- SIGNAL TOPOLOGY (Pure Morphing) ---
@@ -229,14 +245,17 @@ export const Tangle: React.FC = () => {
     }, 4000);
 
     // Resize handler
-    const handleResize = () => {
-      const w = window.innerWidth;
-      const h = window.innerHeight;
-      camera.aspect = w / h;
+    const resizeToMount = () => {
+      const { width, height } = getMountSize();
+      mountWidth = width;
+      camera.aspect = width / height;
       camera.updateProjectionMatrix();
-      renderer.setSize(w, h);
+      renderer.setSize(width, height);
     };
-    window.addEventListener('resize', handleResize);
+    resizeToMount();
+
+    const resizeObserver = new ResizeObserver(resizeToMount);
+    resizeObserver.observe(mountElement);
 
     // Animation
     let animationId: number;
@@ -248,7 +267,7 @@ export const Tangle: React.FC = () => {
       updateGrid(time);
 
       // Camera movement - back to massive wide-angle
-      const isMobile = window.innerWidth < 768;
+      const isMobile = mountWidth < 768;
       const camDist = isMobile ? 220 : 180;
       camera.position.x = Math.sin(time * 0.04) * 60;
       camera.position.y = -80 + Math.cos(time * 0.02) * 20;
@@ -261,7 +280,7 @@ export const Tangle: React.FC = () => {
 
 
     return () => {
-      window.removeEventListener('resize', handleResize);
+      resizeObserver.disconnect();
       cancelAnimationFrame(animationId);
       clearInterval(stateChangeInterval);
 
@@ -277,12 +296,12 @@ export const Tangle: React.FC = () => {
       gridMaterial.dispose();
 
       scene.clear();
-      if (mountRef.current && renderer.domElement) {
-        mountRef.current.removeChild(renderer.domElement);
+      if (mountElement && renderer.domElement && mountElement.contains(renderer.domElement)) {
+        mountElement.removeChild(renderer.domElement);
       }
       renderer.dispose();
     };
-  }, []);
+  }, [exportSettings.isExportMode]);
 
 
   // Quantum channel logs
@@ -317,37 +336,43 @@ export const Tangle: React.FC = () => {
   }, []);
 
   return (
-    <div className="tangle-container">
-      <div
-        ref={mountRef}
-        className="tangle-canvas-container"
-        onClick={() => setShowText(prev => !prev)}
-        style={{ cursor: 'pointer' }}
-      />
+    <ExportFrame aspect={exportSettings.aspect} active={exportSettings.isExportMode}>
+      <div className="tangle-container">
+        <div
+          ref={mountRef}
+          className="tangle-canvas-container"
+          onClick={() => {
+            if (!exportSettings.isExportMode) {
+              setShowText(prev => !prev);
+            }
+          }}
+          style={{ cursor: exportSettings.isExportMode ? 'default' : 'pointer' }}
+        />
 
-      {/* Record Button - Dev only */}
-      {process.env.NODE_ENV !== 'production' && (
-        <button
-          className={`record-button ${isRecording ? 'recording' : ''}`}
-          onClick={toggleRecording}
-          title={isRecording ? 'Stop Recording' : 'Start Recording'}
-        >
-          <span className="record-icon" />
-          {isRecording && <span className="record-time">{formatTime(recordingTime)}</span>}
-        </button>
-      )}
+        {/* Record Button - Dev only */}
+        {process.env.NODE_ENV !== 'production' && !exportSettings.isExportMode && (
+          <button
+            className={`record-button ${isRecording ? 'recording' : ''}`}
+            onClick={toggleRecording}
+            title={isRecording ? 'Stop Recording' : 'Start Recording'}
+          >
+            <span className="record-icon" />
+            {isRecording && <span className="record-time">{formatTime(recordingTime)}</span>}
+          </button>
+        )}
 
-      {/* Quantum Channel - Bottom Left */}
-      {showText && (
-        <div className="tangle-quantum-channel" ref={logContainerRef}>
-          <div className="channel-title">QUANTUM CHANNEL // ENCRYPTED</div>
-          {logs.map((log, i) => (
-            <div key={i} className="channel-entry" style={{ opacity: 0.4 + (i / logs.length) * 0.6 }}>
-              {log}
-            </div>
-          ))}
-        </div>
-      )}
-    </div>
+        {/* Quantum Channel - Bottom Left */}
+        {showText && !exportSettings.isExportMode && (
+          <div className="tangle-quantum-channel" ref={logContainerRef}>
+            <div className="channel-title">QUANTUM CHANNEL // ENCRYPTED</div>
+            {logs.map((log, i) => (
+              <div key={i} className="channel-entry" style={{ opacity: 0.4 + (i / logs.length) * 0.6 }}>
+                {log}
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </ExportFrame>
   );
 };

--- a/src/components/Well/Well.css
+++ b/src/components/Well/Well.css
@@ -1,6 +1,7 @@
 .well-container {
-    position: absolute;
-    inset: 0;
+    position: relative;
+    width: 100%;
+    height: 100%;
     background-color: #000;
     overflow: hidden;
     color: #fff;

--- a/src/components/Well/Well.tsx
+++ b/src/components/Well/Well.tsx
@@ -4,6 +4,9 @@ import { EffectComposer } from 'three/examples/jsm/postprocessing/EffectComposer
 import { RenderPass } from 'three/examples/jsm/postprocessing/RenderPass';
 import { UnrealBloomPass } from 'three/examples/jsm/postprocessing/UnrealBloomPass';
 import { ShaderPass } from 'three/examples/jsm/postprocessing/ShaderPass';
+import { ExportFrame } from '../ExportFrame/ExportFrame';
+import { wellVisualExport } from '../../data/transmissions';
+import { useExportSettings } from '../../lib/exportSettings';
 import './Well.css';
 
 // Custom Shader for Chromatic Aberration, Grain, and Vignette
@@ -71,6 +74,7 @@ const PostProcessShader = {
 
 export const Well: React.FC = () => {
     const mountRef = useRef<HTMLDivElement>(null);
+    const exportSettings = useExportSettings(wellVisualExport);
 
     // Recording state
     const [isRecording, setIsRecording] = useState(false);
@@ -130,26 +134,37 @@ export const Well: React.FC = () => {
 
     useEffect(() => {
         if (!mountRef.current) return;
+        const mountElement = mountRef.current;
 
-        const width = mountRef.current.clientWidth || window.innerWidth;
-        const height = mountRef.current.clientHeight || window.innerHeight;
+        const getMountSize = () => {
+            const rect = mountElement.getBoundingClientRect();
+            const width = rect.width || mountElement.clientWidth || window.innerWidth;
+            const height = rect.height || mountElement.clientHeight || window.innerHeight;
+
+            return {
+                width: Math.max(1, Math.floor(width)),
+                height: Math.max(1, Math.floor(height)),
+            };
+        };
+
+        const initialSize = getMountSize();
 
         const scene = new THREE.Scene();
         scene.background = new THREE.Color(0x000000);
         scene.fog = new THREE.FogExp2(0x000000, 0.0005);
 
-        const camera = new THREE.PerspectiveCamera(65, width / height, 0.1, 8000);
+        const camera = new THREE.PerspectiveCamera(65, initialSize.width / initialSize.height, 0.1, 8000);
         const renderer = new THREE.WebGLRenderer({ antialias: true, alpha: true });
-        renderer.setSize(width, height);
+        renderer.setSize(initialSize.width, initialSize.height);
         renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
-        mountRef.current.appendChild(renderer.domElement);
+        mountElement.appendChild(renderer.domElement);
         canvasRef.current = renderer.domElement;
 
         // --- Composer Setup ---
         const composer = new EffectComposer(renderer);
         composer.addPass(new RenderPass(scene, camera));
 
-        const bloomPass = new UnrealBloomPass(new THREE.Vector2(width, height), 1.5, 0.4, 0.85);
+        const bloomPass = new UnrealBloomPass(new THREE.Vector2(initialSize.width, initialSize.height), 1.5, 0.4, 0.85);
         bloomPass.threshold = 0.15;
         bloomPass.strength = 1.4;
         bloomPass.radius = 0.7;
@@ -353,15 +368,13 @@ export const Well: React.FC = () => {
         camera.lookAt(0, -100, 0);
 
         const resizeObserver = new ResizeObserver(() => {
-            if (!mountRef.current) return;
-            const w = mountRef.current.clientWidth;
-            const h = mountRef.current.clientHeight;
-            camera.aspect = w / h;
+            const { width, height } = getMountSize();
+            camera.aspect = width / height;
             camera.updateProjectionMatrix();
-            renderer.setSize(w, h);
-            composer.setSize(w, h);
+            renderer.setSize(width, height);
+            composer.setSize(width, height);
         });
-        if (mountRef.current) resizeObserver.observe(mountRef.current);
+        resizeObserver.observe(mountElement);
 
         let time = 0;
         let fallProgress = 0;
@@ -461,13 +474,13 @@ export const Well: React.FC = () => {
             // Clear scene
             scene.clear();
 
-            if (mountRef.current && renderer.domElement) {
-                mountRef.current.removeChild(renderer.domElement);
+            if (mountElement && renderer.domElement && mountElement.contains(renderer.domElement)) {
+                mountElement.removeChild(renderer.domElement);
             }
             renderer.dispose();
             composer.dispose();
         };
-    }, []);
+    }, [exportSettings.isExportMode]);
 
     useEffect(() => {
         return () => {
@@ -479,21 +492,25 @@ export const Well: React.FC = () => {
     }, []);
 
     return (
-        <div className="well-container">
-            <div ref={mountRef} className="well-canvas" />
+        <ExportFrame aspect={exportSettings.aspect} active={exportSettings.isExportMode}>
+            <div className="well-container">
+                <div ref={mountRef} className="well-canvas" />
 
-            {process.env.NODE_ENV !== 'production' && (
-                <button
-                    className={`record-button ${isRecording ? 'recording' : ''}`}
-                    onClick={(e) => { e.stopPropagation(); isRecording ? stopRecording() : startRecording(); }}
-                    title={isRecording ? 'Stop Recording' : 'Start Recording'}
-                >
-                    <span className="record-icon" />
-                    {isRecording && <span className="record-time">{formatTime(recordingTime)}</span>}
-                </button>
-            )}
+                {process.env.NODE_ENV !== 'production' && !exportSettings.isExportMode && (
+                    <button
+                        className={`record-button ${isRecording ? 'recording' : ''}`}
+                        onClick={(e) => { e.stopPropagation(); isRecording ? stopRecording() : startRecording(); }}
+                        title={isRecording ? 'Stop Recording' : 'Start Recording'}
+                    >
+                        <span className="record-icon" />
+                        {isRecording && <span className="record-time">{formatTime(recordingTime)}</span>}
+                    </button>
+                )}
 
-            <div className="art-piece-watermark">RECURSIVE_DESCENT // FRACTAL_WELL_03</div>
-        </div>
+                {!exportSettings.isExportMode && (
+                    <div className="art-piece-watermark">RECURSIVE_DESCENT // FRACTAL_WELL_03</div>
+                )}
+            </div>
+        </ExportFrame>
     );
 };

--- a/src/data/transmissions.ts
+++ b/src/data/transmissions.ts
@@ -1,0 +1,576 @@
+import { validateVisualExport } from '../lib/validateVisualExport';
+
+export type TransmissionType =
+  | 'visual'
+  | 'interactive'
+  | 'release'
+  | 'artifact'
+  | 'page'
+  | 'commerce';
+
+export type TransmissionStatus =
+  | 'active'
+  | 'wip'
+  | 'archived'
+  | 'broken';
+
+export type TransmissionVisibility =
+  | 'public'
+  | 'soft-secret'
+  | 'operator-only'
+  | 'deprecated';
+
+export type ExportTarget =
+  | 'canvas'
+  | 'reel'
+  | 'hardware-feed'
+  | 'still'
+  | 'loop';
+
+export type ExportAspectRatio = '9:16' | '16:9' | '1:1' | '4:5';
+
+export type VisualExportCapability = {
+  supportedTargets: ExportTarget[];
+  defaultTarget: ExportTarget;
+  seed: {
+    supported: boolean;
+    defaultMode: 'random' | 'fixed';
+  };
+  duration: {
+    supported: boolean;
+    defaultSeconds?: number;
+    minSeconds?: number;
+    maxSeconds?: number;
+  };
+  aspectRatios: {
+    supported: ExportAspectRatio[];
+    default: ExportAspectRatio;
+  };
+  capture: 'browser-source' | 'external-only';
+  hardwareFeedSafe: boolean;
+  operatorNotes?: string;
+};
+
+export type Transmission = {
+  slug: string;
+  route: string;
+  title: string;
+  type: TransmissionType;
+  status: TransmissionStatus;
+  visibility: TransmissionVisibility;
+  release?: string;
+  tags: string[];
+  exportUse: ExportTarget[];
+  visualExport?: VisualExportCapability;
+  notes?: string;
+  addedAt: string;
+};
+
+export const decayVisualExport: VisualExportCapability = {
+  supportedTargets: ['canvas', 'reel', 'hardware-feed', 'still', 'loop'],
+  defaultTarget: 'canvas',
+  seed: { supported: false, defaultMode: 'random' },
+  duration: { supported: true, defaultSeconds: 8, minSeconds: 3, maxSeconds: 30 },
+  aspectRatios: {
+    supported: ['9:16', '16:9', '1:1', '4:5'],
+    default: '9:16',
+  },
+  capture: 'browser-source',
+  hardwareFeedSafe: true,
+  operatorNotes: 'Non-deterministic. Allow 2-3s warmup before capture for breathing rhythm to establish.',
+};
+
+export const reclamationVisualExport: VisualExportCapability = {
+  supportedTargets: ['canvas', 'reel', 'still', 'loop'],
+  defaultTarget: 'canvas',
+  seed: { supported: false, defaultMode: 'random' },
+  duration: { supported: true, defaultSeconds: 12, minSeconds: 6, maxSeconds: 60 },
+  aspectRatios: {
+    supported: ['9:16', '16:9', '1:1', '4:5'],
+    default: '9:16',
+  },
+  capture: 'browser-source',
+  hardwareFeedSafe: false,
+  operatorNotes: 'Non-deterministic bloom cycle. Export mode hides the HUD and dev recording button; allow enough lead time for growth phase selection.',
+};
+
+export const broadcastVisualExport: VisualExportCapability = {
+  supportedTargets: ['canvas', 'reel', 'still', 'loop'],
+  defaultTarget: 'canvas',
+  seed: { supported: false, defaultMode: 'random' },
+  duration: { supported: true, defaultSeconds: 8, minSeconds: 3, maxSeconds: 30 },
+  aspectRatios: {
+    supported: ['9:16', '16:9', '1:1', '4:5'],
+    default: '9:16',
+  },
+  capture: 'browser-source',
+  hardwareFeedSafe: false,
+  operatorNotes: 'Non-deterministic relay tower. Ring bursts and audio remain click-triggered, so hardware-feed is not promised in v1.',
+};
+
+export const forestVisualExport: VisualExportCapability = {
+  supportedTargets: ['canvas', 'reel', 'hardware-feed', 'still', 'loop'],
+  defaultTarget: 'canvas',
+  seed: { supported: false, defaultMode: 'random' },
+  duration: { supported: true, defaultSeconds: 12, minSeconds: 3, maxSeconds: 60 },
+  aspectRatios: {
+    supported: ['9:16', '16:9', '1:1', '4:5'],
+    default: '9:16',
+  },
+  capture: 'browser-source',
+  hardwareFeedSafe: true,
+  operatorNotes: 'Non-deterministic forest drift. Useful unattended after load with fireflies and tree traces active.',
+};
+
+export const resonanceVisualExport: VisualExportCapability = {
+  supportedTargets: ['canvas', 'reel', 'hardware-feed', 'still', 'loop'],
+  defaultTarget: 'canvas',
+  seed: { supported: false, defaultMode: 'random' },
+  duration: { supported: true, defaultSeconds: 12, minSeconds: 3, maxSeconds: 60 },
+  aspectRatios: {
+    supported: ['9:16', '16:9', '1:1', '4:5'],
+    default: '9:16',
+  },
+  capture: 'browser-source',
+  hardwareFeedSafe: true,
+  operatorNotes: 'Non-deterministic resonance field. Export mode hides the click-toggled logs for clean capture.',
+};
+
+export const growthVisualExport: VisualExportCapability = {
+  supportedTargets: ['canvas', 'reel', 'hardware-feed', 'still', 'loop'],
+  defaultTarget: 'canvas',
+  seed: { supported: false, defaultMode: 'random' },
+  duration: { supported: true, defaultSeconds: 12, minSeconds: 3, maxSeconds: 60 },
+  aspectRatios: {
+    supported: ['9:16', '16:9', '1:1', '4:5'],
+    default: '9:16',
+  },
+  capture: 'browser-source',
+  hardwareFeedSafe: true,
+  operatorNotes: 'Non-deterministic branching system. Export mode hides the click-toggled logs for clean capture.',
+};
+
+export const forbiddingVisualExport: VisualExportCapability = {
+  supportedTargets: ['canvas', 'reel', 'hardware-feed', 'still', 'loop'],
+  defaultTarget: 'canvas',
+  seed: { supported: false, defaultMode: 'random' },
+  duration: { supported: true, defaultSeconds: 8, minSeconds: 3, maxSeconds: 30 },
+  aspectRatios: {
+    supported: ['9:16', '16:9', '1:1', '4:5'],
+    default: '9:16',
+  },
+  capture: 'browser-source',
+  hardwareFeedSafe: true,
+  operatorNotes: 'Non-deterministic monolith field. Works unattended with slow camera drift.',
+};
+
+export const wellVisualExport: VisualExportCapability = {
+  supportedTargets: ['canvas', 'reel', 'hardware-feed', 'still', 'loop'],
+  defaultTarget: 'canvas',
+  seed: { supported: false, defaultMode: 'random' },
+  duration: { supported: true, defaultSeconds: 12, minSeconds: 3, maxSeconds: 60 },
+  aspectRatios: {
+    supported: ['9:16', '16:9', '1:1', '4:5'],
+    default: '9:16',
+  },
+  capture: 'browser-source',
+  hardwareFeedSafe: true,
+  operatorNotes: 'Non-deterministic recursive descent. Works unattended with continuous fall motion.',
+};
+
+export const tangleVisualExport: VisualExportCapability = {
+  supportedTargets: ['canvas', 'reel', 'hardware-feed', 'still', 'loop'],
+  defaultTarget: 'canvas',
+  seed: { supported: false, defaultMode: 'random' },
+  duration: { supported: true, defaultSeconds: 8, minSeconds: 3, maxSeconds: 30 },
+  aspectRatios: {
+    supported: ['9:16', '16:9', '1:1', '4:5'],
+    default: '9:16',
+  },
+  capture: 'browser-source',
+  hardwareFeedSafe: true,
+  operatorNotes: 'Non-deterministic signal topology. Export mode disables the click-toggled quantum log overlay.',
+};
+
+export const learningVisualExport: VisualExportCapability = {
+  supportedTargets: ['canvas', 'reel', 'hardware-feed', 'still', 'loop'],
+  defaultTarget: 'canvas',
+  seed: { supported: false, defaultMode: 'random' },
+  duration: { supported: true, defaultSeconds: 8, minSeconds: 3, maxSeconds: 30 },
+  aspectRatios: {
+    supported: ['9:16', '16:9', '1:1', '4:5'],
+    default: '9:16',
+  },
+  capture: 'browser-source',
+  hardwareFeedSafe: true,
+  operatorNotes: 'Non-deterministic learning landscape. Export mode hides the policy matrix overlay for clean source capture.',
+};
+
+export const stepwellVisualExport: VisualExportCapability = {
+  supportedTargets: ['canvas', 'reel', 'hardware-feed', 'still', 'loop'],
+  defaultTarget: 'canvas',
+  seed: { supported: false, defaultMode: 'random' },
+  duration: { supported: true, defaultSeconds: 12, minSeconds: 3, maxSeconds: 60 },
+  aspectRatios: {
+    supported: ['9:16', '16:9', '1:1', '4:5'],
+    default: '9:16',
+  },
+  capture: 'browser-source',
+  hardwareFeedSafe: true,
+  operatorNotes: 'Non-deterministic recursive descent. Export mode hides the coordinate and log UI.',
+};
+
+export const nerveVisualExport: VisualExportCapability = {
+  supportedTargets: ['canvas', 'reel', 'hardware-feed', 'still', 'loop'],
+  defaultTarget: 'canvas',
+  seed: { supported: false, defaultMode: 'random' },
+  duration: { supported: true, defaultSeconds: 8, minSeconds: 3, maxSeconds: 30 },
+  aspectRatios: {
+    supported: ['9:16', '16:9', '1:1', '4:5'],
+    default: '9:16',
+  },
+  capture: 'browser-source',
+  hardwareFeedSafe: true,
+  operatorNotes: 'Non-deterministic nerve network. Useful unattended with autonomous pulse propagation.',
+};
+
+export const faceVisualExport: VisualExportCapability = {
+  supportedTargets: ['canvas', 'reel', 'hardware-feed', 'still', 'loop'],
+  defaultTarget: 'canvas',
+  seed: { supported: false, defaultMode: 'random' },
+  duration: { supported: true, defaultSeconds: 8, minSeconds: 3, maxSeconds: 30 },
+  aspectRatios: {
+    supported: ['9:16', '16:9', '1:1', '4:5'],
+    default: '9:16',
+  },
+  capture: 'browser-source',
+  hardwareFeedSafe: true,
+  operatorNotes: 'Non-deterministic model route. Allow model load before capture.',
+};
+
+export const handVisualExport: VisualExportCapability = {
+  supportedTargets: ['canvas', 'reel', 'hardware-feed', 'still', 'loop'],
+  defaultTarget: 'canvas',
+  seed: { supported: false, defaultMode: 'random' },
+  duration: { supported: true, defaultSeconds: 8, minSeconds: 3, maxSeconds: 30 },
+  aspectRatios: {
+    supported: ['9:16', '16:9', '1:1', '4:5'],
+    default: '9:16',
+  },
+  capture: 'browser-source',
+  hardwareFeedSafe: true,
+  operatorNotes: 'Non-deterministic model route. Allow skeleton-hand load before capture.',
+};
+
+export const birthVisualExport: VisualExportCapability = {
+  supportedTargets: ['canvas', 'reel', 'hardware-feed', 'still', 'loop'],
+  defaultTarget: 'canvas',
+  seed: { supported: false, defaultMode: 'random' },
+  duration: { supported: true, defaultSeconds: 8, minSeconds: 3, maxSeconds: 30 },
+  aspectRatios: {
+    supported: ['9:16', '16:9', '1:1', '4:5'],
+    default: '9:16',
+  },
+  capture: 'browser-source',
+  hardwareFeedSafe: true,
+  operatorNotes: 'Non-deterministic model route. Allow skeleton-hand load before capture.',
+};
+
+export const murmurVisualExport: VisualExportCapability = {
+  supportedTargets: ['canvas', 'reel', 'hardware-feed', 'still', 'loop'],
+  defaultTarget: 'canvas',
+  seed: { supported: false, defaultMode: 'random' },
+  duration: { supported: true, defaultSeconds: 26, minSeconds: 3, maxSeconds: 60 },
+  aspectRatios: {
+    supported: ['9:16', '16:9', '1:1', '4:5'],
+    default: '9:16',
+  },
+  capture: 'browser-source',
+  hardwareFeedSafe: true,
+  operatorNotes: 'Non-deterministic flocking cycle. Full logo convergence cycle is about 26 seconds.',
+};
+
+export const transmissions: Transmission[] = [
+  {
+    slug: 'home',
+    route: '/',
+    title: 'PUBLIC PORTAL',
+    type: 'page',
+    status: 'active',
+    visibility: 'public',
+    tags: ['home', 'portal', 'audio'],
+    exportUse: [],
+    notes: 'Primary public entry point. Keep sparse, direct, and free of operator navigation.',
+    addedAt: '2026-05-07',
+  },
+  {
+    slug: 'terminal',
+    route: '/terminal',
+    title: 'B.A.N.I.S TERMINAL',
+    type: 'interactive',
+    status: 'active',
+    visibility: 'public',
+    tags: ['terminal', 'commands', 'archive'],
+    exportUse: [],
+    notes: 'Public command surface. Operator routes remain undisclosed unless intentionally leaked later.',
+    addedAt: '2026-05-07',
+  },
+  {
+    slug: 'instruments',
+    route: '/instruments',
+    title: 'INSTRUMENT RACKS',
+    type: 'commerce',
+    status: 'active',
+    visibility: 'public',
+    tags: ['racks', 'commerce', 'downloads'],
+    exportUse: [],
+    notes: 'Public rack acquisition route backed by payment rails.',
+    addedAt: '2026-05-07',
+  },
+  {
+    slug: 'instruments-success',
+    route: '/instruments/success',
+    title: 'INSTRUMENT DELIVERY',
+    type: 'commerce',
+    status: 'active',
+    visibility: 'public',
+    tags: ['racks', 'payment', 'delivery'],
+    exportUse: [],
+    notes: 'Post-checkout delivery route for instrument rack downloads.',
+    addedAt: '2026-05-07',
+  },
+  {
+    slug: 'terms',
+    route: '/terms',
+    title: 'TERMS',
+    type: 'page',
+    status: 'active',
+    visibility: 'public',
+    tags: ['terms', 'commerce', 'policy'],
+    exportUse: [],
+    addedAt: '2026-05-07',
+  },
+  {
+    slug: 'testblandingpage',
+    route: '/testblandingpage',
+    title: 'LEGACY RESONANCE REDIRECT',
+    type: 'page',
+    status: 'archived',
+    visibility: 'deprecated',
+    tags: ['legacy', 'redirect', 'resonance'],
+    exportUse: [],
+    notes: 'Compatibility route that redirects to /resonance.',
+    addedAt: '2026-05-07',
+  },
+  {
+    slug: 'decay',
+    route: '/decay',
+    title: 'DECAY SIGNAL',
+    type: 'visual',
+    status: 'active',
+    visibility: 'soft-secret',
+    release: 'Decay',
+    tags: ['entropy', 'shell', 'strain', 'geometry', 'release-decay'],
+    exportUse: ['canvas', 'reel', 'hardware-feed', 'still', 'loop'],
+    visualExport: decayVisualExport,
+    notes: 'Good source for slow breathing motion and degraded geometric tension.',
+    addedAt: '2026-05-07',
+  },
+  {
+    slug: 'reclamation',
+    route: '/reclamation',
+    title: 'RECLAMATION BLOOM',
+    type: 'visual',
+    status: 'active',
+    visibility: 'soft-secret',
+    tags: ['reclamation', 'bloom', 'ash', 'growth'],
+    exportUse: ['canvas', 'reel', 'still', 'loop'],
+    visualExport: reclamationVisualExport,
+    notes: 'Blooming visual system for recovery, ash, and softened mechanical growth.',
+    addedAt: '2026-05-07',
+  },
+  {
+    slug: 'broadcast',
+    route: '/broadcast',
+    title: 'BROADCAST RELAY',
+    type: 'visual',
+    status: 'active',
+    visibility: 'soft-secret',
+    tags: ['broadcast', 'numbers-station', 'tower', 'signal'],
+    exportUse: ['canvas', 'reel', 'still', 'loop'],
+    visualExport: broadcastVisualExport,
+    addedAt: '2026-05-07',
+  },
+  {
+    slug: 'forest',
+    route: '/forest',
+    title: 'FOREST ARRAY',
+    type: 'visual',
+    status: 'active',
+    visibility: 'soft-secret',
+    tags: ['forest', 'growth', 'fireflies', 'instanced'],
+    exportUse: ['canvas', 'reel', 'hardware-feed', 'still', 'loop'],
+    visualExport: forestVisualExport,
+    addedAt: '2026-05-07',
+  },
+  {
+    slug: 'resonance',
+    route: '/resonance',
+    title: 'RESONANCE FIELD',
+    type: 'visual',
+    status: 'active',
+    visibility: 'soft-secret',
+    tags: ['resonance', 'field', 'signal'],
+    exportUse: ['canvas', 'reel', 'hardware-feed', 'still', 'loop'],
+    visualExport: resonanceVisualExport,
+    addedAt: '2026-05-07',
+  },
+  {
+    slug: 'growth',
+    route: '/growth',
+    title: 'GROWTH SYSTEM',
+    type: 'visual',
+    status: 'active',
+    visibility: 'soft-secret',
+    tags: ['growth', 'organic', 'signal'],
+    exportUse: ['canvas', 'reel', 'hardware-feed', 'still', 'loop'],
+    visualExport: growthVisualExport,
+    addedAt: '2026-05-07',
+  },
+  {
+    slug: 'forbidding',
+    route: '/forbidding',
+    title: 'FORBIDDING BLOCKS',
+    type: 'visual',
+    status: 'active',
+    visibility: 'soft-secret',
+    tags: ['forbidding', 'blocks', 'bass', 'architecture'],
+    exportUse: ['canvas', 'reel', 'hardware-feed', 'still', 'loop'],
+    visualExport: forbiddingVisualExport,
+    addedAt: '2026-05-07',
+  },
+  {
+    slug: 'well',
+    route: '/well',
+    title: 'WELL',
+    type: 'visual',
+    status: 'active',
+    visibility: 'soft-secret',
+    tags: ['well', 'depth', 'submerged'],
+    exportUse: ['canvas', 'reel', 'hardware-feed', 'still', 'loop'],
+    visualExport: wellVisualExport,
+    addedAt: '2026-05-07',
+  },
+  {
+    slug: 'tangle',
+    route: '/tangle',
+    title: 'TANGLE',
+    type: 'visual',
+    status: 'active',
+    visibility: 'soft-secret',
+    tags: ['tangle', 'network', 'constraint'],
+    exportUse: ['canvas', 'reel', 'hardware-feed', 'still', 'loop'],
+    visualExport: tangleVisualExport,
+    addedAt: '2026-05-07',
+  },
+  {
+    slug: 'learning',
+    route: '/learning',
+    title: 'LEARNING',
+    type: 'visual',
+    status: 'active',
+    visibility: 'soft-secret',
+    tags: ['learning', 'system', 'behavior'],
+    exportUse: ['canvas', 'reel', 'hardware-feed', 'still', 'loop'],
+    visualExport: learningVisualExport,
+    addedAt: '2026-05-07',
+  },
+  {
+    slug: 'stepwell',
+    route: '/stepwell',
+    title: 'STEPWELL',
+    type: 'visual',
+    status: 'active',
+    visibility: 'soft-secret',
+    tags: ['stepwell', 'pluck', 'architecture'],
+    exportUse: ['canvas', 'reel', 'hardware-feed', 'still', 'loop'],
+    visualExport: stepwellVisualExport,
+    addedAt: '2026-05-07',
+  },
+  {
+    slug: 'nerve',
+    route: '/nerve',
+    title: 'NERVE',
+    type: 'visual',
+    status: 'active',
+    visibility: 'soft-secret',
+    tags: ['nerve', 'edge', 'impulse'],
+    exportUse: ['canvas', 'reel', 'hardware-feed', 'still', 'loop'],
+    visualExport: nerveVisualExport,
+    addedAt: '2026-05-07',
+  },
+  {
+    slug: 'face',
+    route: '/face',
+    title: 'FACE',
+    type: 'visual',
+    status: 'active',
+    visibility: 'soft-secret',
+    tags: ['face', 'model', 'figure'],
+    exportUse: ['canvas', 'reel', 'hardware-feed', 'still', 'loop'],
+    visualExport: faceVisualExport,
+    addedAt: '2026-05-07',
+  },
+  {
+    slug: 'hand',
+    route: '/hand',
+    title: 'HAND',
+    type: 'visual',
+    status: 'active',
+    visibility: 'soft-secret',
+    tags: ['hand', 'model', 'gesture'],
+    exportUse: ['canvas', 'reel', 'hardware-feed', 'still', 'loop'],
+    visualExport: handVisualExport,
+    addedAt: '2026-05-07',
+  },
+  {
+    slug: 'birth',
+    route: '/birth',
+    title: 'BIRTH',
+    type: 'visual',
+    status: 'active',
+    visibility: 'soft-secret',
+    tags: ['birth', 'model', 'emergence'],
+    exportUse: ['canvas', 'reel', 'hardware-feed', 'still', 'loop'],
+    visualExport: birthVisualExport,
+    addedAt: '2026-05-07',
+  },
+  {
+    slug: 'murmur',
+    route: '/murmur',
+    title: 'MURMUR',
+    type: 'visual',
+    status: 'active',
+    visibility: 'soft-secret',
+    tags: ['murmur', 'signal', 'texture'],
+    exportUse: ['canvas', 'reel', 'hardware-feed', 'still', 'loop'],
+    visualExport: murmurVisualExport,
+    addedAt: '2026-05-07',
+  },
+];
+
+for (const transmission of transmissions) {
+  if (!transmission.visualExport) {
+    continue;
+  }
+
+  const validationErrors = validateVisualExport(transmission.visualExport);
+  if (validationErrors.length > 0) {
+    console.error(
+      `[visual-export] ${transmission.route} invalid visualExport metadata: ${validationErrors.join('; ')}`,
+    );
+  }
+}
+
+export const getTransmissionBySlug = (slug: string) =>
+  transmissions.find((transmission) => transmission.slug === slug);

--- a/src/lib/exportSettings.ts
+++ b/src/lib/exportSettings.ts
@@ -1,0 +1,97 @@
+import { useEffect, useMemo } from 'react';
+import { useSearchParams } from 'react-router-dom';
+import type { ExportTarget, VisualExportCapability } from '../data/transmissions';
+
+export type AspectRatio = '9:16' | '16:9' | '1:1' | '4:5';
+
+export type ExportSettings = {
+  isExportMode: boolean;
+  target: ExportTarget;
+  requestedTarget: ExportTarget | null;
+  fellBackToDefault: boolean;
+  seed: string | null;
+  duration: number | null;
+  aspect: AspectRatio;
+};
+
+const VALID_TARGETS: ExportTarget[] = ['canvas', 'reel', 'hardware-feed', 'still', 'loop'];
+const VALID_ASPECTS: AspectRatio[] = ['9:16', '16:9', '1:1', '4:5'];
+
+const isExportTarget = (value: string | null): value is ExportTarget =>
+  value !== null && VALID_TARGETS.includes(value as ExportTarget);
+
+const isAspectRatio = (value: string | null): value is AspectRatio =>
+  value !== null && VALID_ASPECTS.includes(value as AspectRatio);
+
+const getRoutePath = () => {
+  if (typeof window === 'undefined') {
+    return 'unknown route';
+  }
+
+  return window.location.pathname;
+};
+
+const resolveDuration = (
+  value: string | null,
+  capability: VisualExportCapability,
+) => {
+  if (!value || !capability.duration.supported) {
+    return null;
+  }
+
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed)) {
+    return null;
+  }
+
+  const { minSeconds, maxSeconds } = capability.duration;
+  if (typeof minSeconds === 'number' && typeof maxSeconds === 'number') {
+    return Math.min(Math.max(parsed, minSeconds), maxSeconds);
+  }
+
+  return parsed;
+};
+
+export function resolveSettings(
+  params: URLSearchParams,
+  capability: VisualExportCapability,
+): ExportSettings {
+  const rawTarget = params.get('target');
+  const isExportMode = params.has('target');
+  const requestedTarget = isExportTarget(rawTarget) ? rawTarget : null;
+  const targetIsSupported = requestedTarget !== null && capability.supportedTargets.includes(requestedTarget);
+  const fellBackToDefault = isExportMode && !targetIsSupported;
+  const target = targetIsSupported ? requestedTarget : capability.defaultTarget;
+
+  const rawAspect = params.get('aspect');
+  const aspect = isAspectRatio(rawAspect) && capability.aspectRatios.supported.includes(rawAspect)
+    ? rawAspect
+    : capability.aspectRatios.default;
+
+  return {
+    isExportMode,
+    target,
+    requestedTarget,
+    fellBackToDefault,
+    seed: params.get('seed'),
+    duration: resolveDuration(params.get('duration'), capability),
+    aspect,
+  };
+}
+
+export function useExportSettings(capability: VisualExportCapability): ExportSettings {
+  const [params] = useSearchParams();
+  const settings = useMemo(() => resolveSettings(params, capability), [params, capability]);
+
+  useEffect(() => {
+    if (!settings.fellBackToDefault) {
+      return;
+    }
+
+    console.warn(
+      `[visual-export] ${getRoutePath()} unsupported target: ${params.get('target') ?? 'empty'}; falling back to ${settings.target}`,
+    );
+  }, [params, settings.fellBackToDefault, settings.target]);
+
+  return settings;
+}

--- a/src/lib/validateVisualExport.ts
+++ b/src/lib/validateVisualExport.ts
@@ -1,0 +1,43 @@
+import type { ExportTarget, VisualExportCapability } from '../data/transmissions';
+
+const VALID_TARGETS: ExportTarget[] = ['canvas', 'reel', 'hardware-feed', 'still', 'loop'];
+
+export function validateVisualExport(capability: VisualExportCapability): string[] {
+  const errors: string[] = [];
+
+  if (!capability.supportedTargets.includes(capability.defaultTarget)) {
+    errors.push(`defaultTarget "${capability.defaultTarget}" is not in supportedTargets`);
+  }
+
+  if (!capability.aspectRatios.supported.includes(capability.aspectRatios.default)) {
+    errors.push(`aspectRatios.default "${capability.aspectRatios.default}" is not in aspectRatios.supported`);
+  }
+
+  const { defaultSeconds, minSeconds, maxSeconds } = capability.duration;
+
+  if (
+    typeof minSeconds === 'number' &&
+    typeof maxSeconds === 'number' &&
+    minSeconds > maxSeconds
+  ) {
+    errors.push(`duration.minSeconds ${minSeconds} is greater than duration.maxSeconds ${maxSeconds}`);
+  }
+
+  if (typeof defaultSeconds === 'number') {
+    if (typeof minSeconds === 'number' && defaultSeconds < minSeconds) {
+      errors.push(`duration.defaultSeconds ${defaultSeconds} is less than duration.minSeconds ${minSeconds}`);
+    }
+
+    if (typeof maxSeconds === 'number' && defaultSeconds > maxSeconds) {
+      errors.push(`duration.defaultSeconds ${defaultSeconds} is greater than duration.maxSeconds ${maxSeconds}`);
+    }
+  }
+
+  for (const target of capability.supportedTargets) {
+    if (!VALID_TARGETS.includes(target)) {
+      errors.push(`unsupported export target "${target}"`);
+    }
+  }
+
+  return errors;
+}


### PR DESCRIPTION
## Summary
- **Operator registry** — hidden `/operator` route: a searchable/filterable index of all routes and transmissions plus per-entry detail pages, backed by `src/data/transmissions.ts`. Kept out of search engines via `public/robots.txt` + Netlify `X-Robots-Tag: noindex` headers.
- **Visual export v1** — record/export every visual route at locked aspect ratios (9:16, 16:9, 1:1, 4:5) via a `?target=` URL switch. Adds shared infra (`lib/exportSettings`, `lib/validateVisualExport`, `ExportFrame`) and wires all 16 visual routes to letterbox to the chosen aspect and hide HUDs/record buttons during capture. Operator UI surfaces each route's export capability.

Scope: 44 files, +3,822/−640. `.beads/` tracking churn intentionally excluded.

## Verification
- [x] `tsc --noEmit` clean (no type errors)
- [x] `npm run build` clean — only pre-existing asset-size warnings (mp3s/logos), unrelated to this change
- [ ] Manual browser checklist — load representative routes with `?target=canvas`, confirm correct framing + hidden HUD/record button, confirm `/operator` table populates. See `feature-dev-docs/feature-dev-visual-export/handoff.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)